### PR TITLE
Wire up Settings, About, and Help buttons in MainActivity

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -32,6 +32,7 @@ android {
     }
     buildFeatures {
         compose = true
+        buildConfig = true
     }
 }
 

--- a/app/src/main/kotlin/com/shagalalab/qqkeyboard/MainActivity.kt
+++ b/app/src/main/kotlin/com/shagalalab/qqkeyboard/MainActivity.kt
@@ -9,6 +9,7 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxSize
@@ -86,7 +87,10 @@ fun MainScreen(
     onHelpClick: () -> Unit = {},
 ) {
     Column(modifier.fillMaxWidth()) {
-        TopAppBar(title = { Text(stringResource(R.string.app_name)) })
+        TopAppBar(
+            title = { Text(stringResource(R.string.app_name)) },
+            windowInsets = WindowInsets(0)
+        )
 
         Column(
             Modifier

--- a/app/src/main/kotlin/com/shagalalab/qqkeyboard/MainActivity.kt
+++ b/app/src/main/kotlin/com/shagalalab/qqkeyboard/MainActivity.kt
@@ -24,16 +24,22 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.shagalalab.qqkeyboard.ui.settings.AboutScreen
+import com.shagalalab.qqkeyboard.ui.settings.HelpScreen
 import com.shagalalab.qqkeyboard.ui.settings.KeyboardSettingsScreen
 import com.shagalalab.qqkeyboard.ui.theme.QqKeyboardTheme
+
+private enum class Screen { Main, Settings, About, Help }
 
 class MainActivity : ComponentActivity() {
     @OptIn(ExperimentalMaterial3Api::class)
@@ -52,16 +58,25 @@ class MainActivity : ComponentActivity() {
                     },
                     modifier = Modifier.fillMaxSize()
                 ) { innerPadding ->
-                    val (showSettings, setShowSettings) = remember { mutableStateOf(false) }
+                    var currentScreen by remember { mutableStateOf(Screen.Main) }
 
-                    if (showSettings) {
-                        KeyboardSettingsScreen(
-                            onBackClick = { setShowSettings(false) },
+                    when (currentScreen) {
+                        Screen.Settings -> KeyboardSettingsScreen(
+                            onBackClick = { currentScreen = Screen.Main },
                             modifier = Modifier.padding(innerPadding)
                         )
-                    } else {
-                        MainScreen(
-                            onSettingsClick = { setShowSettings(true) },
+                        Screen.About -> AboutScreen(
+                            onBackClick = { currentScreen = Screen.Main },
+                            modifier = Modifier.padding(innerPadding)
+                        )
+                        Screen.Help -> HelpScreen(
+                            onBackClick = { currentScreen = Screen.Main },
+                            modifier = Modifier.padding(innerPadding)
+                        )
+                        Screen.Main -> MainScreen(
+                            onSettingsClick = { currentScreen = Screen.Settings },
+                            onAboutClick = { currentScreen = Screen.About },
+                            onHelpClick = { currentScreen = Screen.Help },
                             modifier = Modifier.padding(innerPadding)
                         )
                     }
@@ -75,6 +90,8 @@ class MainActivity : ComponentActivity() {
 fun MainScreen(
     modifier: Modifier = Modifier,
     onSettingsClick: () -> Unit = {},
+    onAboutClick: () -> Unit = {},
+    onHelpClick: () -> Unit = {},
 ) {
     Column(modifier
         .padding(16.dp)
@@ -95,19 +112,13 @@ fun MainScreen(
         }) {
             Text(text = stringResource(R.string.change_default_keyboard))
         }
-        Button(modifier = Modifier.fillMaxWidth(), onClick = {
-            // TODO: go to keyboard settings
-        }) {
+        Button(modifier = Modifier.fillMaxWidth(), onClick = onSettingsClick) {
             Text(text = stringResource(R.string.keyboard_settings))
         }
-        Button(modifier = Modifier.fillMaxWidth(), onClick = {
-            // TODO: go to about screen
-        }) {
+        Button(modifier = Modifier.fillMaxWidth(), onClick = onAboutClick) {
             Text(text = stringResource(R.string.about_keyboard))
         }
-        Button(modifier = Modifier.fillMaxWidth(), onClick = {
-            // TODO: go to help screen
-        }) {
+        Button(modifier = Modifier.fillMaxWidth(), onClick = onHelpClick) {
             Text(text = stringResource(R.string.help))
         }
 

--- a/app/src/main/kotlin/com/shagalalab/qqkeyboard/MainActivity.kt
+++ b/app/src/main/kotlin/com/shagalalab/qqkeyboard/MainActivity.kt
@@ -48,16 +48,7 @@ class MainActivity : ComponentActivity() {
         enableEdgeToEdge()
         setContent {
             QqKeyboardTheme {
-                Scaffold(
-                    topBar = {
-                        TopAppBar(
-                            title = {
-                                Text(stringResource(R.string.app_name))
-                            }
-                        )
-                    },
-                    modifier = Modifier.fillMaxSize()
-                ) { innerPadding ->
+                Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
                     var currentScreen by remember { mutableStateOf(Screen.Main) }
 
                     when (currentScreen) {
@@ -86,6 +77,7 @@ class MainActivity : ComponentActivity() {
     }
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun MainScreen(
     modifier: Modifier = Modifier,
@@ -93,12 +85,16 @@ fun MainScreen(
     onAboutClick: () -> Unit = {},
     onHelpClick: () -> Unit = {},
 ) {
-    Column(modifier
-        .padding(16.dp)
-        .verticalScroll(rememberScrollState())
-        .fillMaxWidth(),
-        verticalArrangement = Arrangement.spacedBy(16.dp)
-    ) {
+    Column(modifier.fillMaxWidth()) {
+        TopAppBar(title = { Text(stringResource(R.string.app_name)) })
+
+        Column(
+            Modifier
+                .padding(16.dp)
+                .verticalScroll(rememberScrollState())
+                .fillMaxWidth(),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
         val context = LocalContext.current
         val (text, setTextValue) = remember { mutableStateOf(TextFieldValue("")) }
 
@@ -131,6 +127,7 @@ fun MainScreen(
             shape = RoundedCornerShape(16.dp),
             placeholder = { Text(stringResource(R.string.test_keyboard_here)) }
         )
+        }
     }
 }
 

--- a/app/src/main/kotlin/com/shagalalab/qqkeyboard/ui/settings/AboutScreen.kt
+++ b/app/src/main/kotlin/com/shagalalab/qqkeyboard/ui/settings/AboutScreen.kt
@@ -1,0 +1,106 @@
+package com.shagalalab.qqkeyboard.ui.settings
+
+import android.content.Intent
+import android.net.Uri
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Card
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.dp
+import com.shagalalab.qqkeyboard.BuildConfig
+import com.shagalalab.qqkeyboard.R
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AboutScreen(
+    onBackClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val context = LocalContext.current
+
+    Column(modifier = modifier.fillMaxSize()) {
+        TopAppBar(
+            title = { Text("About") },
+            navigationIcon = {
+                IconButton(onClick = onBackClick) {
+                    Icon(painterResource(R.drawable.arrow_back_24px), contentDescription = "Back")
+                }
+            }
+        )
+
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            Card(modifier = Modifier.fillMaxWidth()) {
+                Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    Text("QqKeyboard", style = MaterialTheme.typography.headlineSmall)
+                    Text(
+                        "Version ${BuildConfig.VERSION_NAME}",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                    Spacer(modifier = Modifier.height(4.dp))
+                    Text(
+                        "A virtual keyboard for the Karakalpak language, supporting both Latin (QQ) " +
+                            "and Cyrillic (ҚҚ) scripts. Built with Jetpack Compose.",
+                        style = MaterialTheme.typography.bodyMedium
+                    )
+                }
+            }
+
+            Card(modifier = Modifier.fillMaxWidth()) {
+                Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                    Text("Developer", style = MaterialTheme.typography.titleMedium)
+                    Spacer(modifier = Modifier.height(4.dp))
+                    Text("Shagala Lab", style = MaterialTheme.typography.bodyMedium)
+                    TextButton(
+                        onClick = {
+                            context.startActivity(
+                                Intent(Intent.ACTION_VIEW, Uri.parse("https://github.com/shagalalab/qqkeyboard-android2"))
+                            )
+                        },
+                        modifier = Modifier.padding(0.dp)
+                    ) {
+                        Text("View on GitHub")
+                    }
+                }
+            }
+
+            Card(modifier = Modifier.fillMaxWidth()) {
+                Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    Text("Features", style = MaterialTheme.typography.titleMedium)
+                    Text(
+                        "• Latin and Cyrillic Karakalpak layouts\n" +
+                            "• Emoji panel with recent emoji tracking\n" +
+                            "• Auto-capitalization after sentences\n" +
+                            "• Double-space converts to period\n" +
+                            "• Double-tap Shift for Caps Lock\n" +
+                            "• Haptic and sound feedback",
+                        style = MaterialTheme.typography.bodyMedium
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/com/shagalalab/qqkeyboard/ui/settings/AboutScreen.kt
+++ b/app/src/main/kotlin/com/shagalalab/qqkeyboard/ui/settings/AboutScreen.kt
@@ -3,6 +3,7 @@ package com.shagalalab.qqkeyboard.ui.settings
 import android.content.Intent
 import android.net.Uri
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -42,7 +43,8 @@ fun AboutScreen(
                 IconButton(onClick = onBackClick) {
                     Icon(painterResource(R.drawable.arrow_back_24px), contentDescription = "Back")
                 }
-            }
+            },
+            windowInsets = WindowInsets(0)
         )
 
         Column(

--- a/app/src/main/kotlin/com/shagalalab/qqkeyboard/ui/settings/HelpScreen.kt
+++ b/app/src/main/kotlin/com/shagalalab/qqkeyboard/ui/settings/HelpScreen.kt
@@ -1,0 +1,119 @@
+package com.shagalalab.qqkeyboard.ui.settings
+
+import android.content.Context.INPUT_METHOD_SERVICE
+import android.content.Intent
+import android.provider.Settings
+import android.view.inputmethod.InputMethodManager
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.dp
+import com.shagalalab.qqkeyboard.R
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun HelpScreen(
+    onBackClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val context = LocalContext.current
+
+    Column(modifier = modifier.fillMaxSize()) {
+        TopAppBar(
+            title = { Text("Help") },
+            navigationIcon = {
+                IconButton(onClick = onBackClick) {
+                    Icon(painterResource(R.drawable.arrow_back_24px), contentDescription = "Back")
+                }
+            }
+        )
+
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            Card(modifier = Modifier.fillMaxWidth()) {
+                Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                    Text("Setup", style = MaterialTheme.typography.titleMedium)
+
+                    Text("Step 1 — Enable the keyboard", style = MaterialTheme.typography.titleSmall)
+                    Text(
+                        "Go to Android Settings → System → Language & Input → On-screen keyboard, " +
+                            "then enable QqKeyboard.",
+                        style = MaterialTheme.typography.bodyMedium
+                    )
+                    Button(
+                        onClick = { context.startActivity(Intent(Settings.ACTION_INPUT_METHOD_SETTINGS)) },
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
+                        Text("Open Input Method Settings")
+                    }
+
+                    Text("Step 2 — Set as default keyboard", style = MaterialTheme.typography.titleSmall)
+                    Text(
+                        "Tap the keyboard icon in the navigation bar while typing, or use the button below.",
+                        style = MaterialTheme.typography.bodyMedium
+                    )
+                    Button(
+                        onClick = {
+                            (context.getSystemService(INPUT_METHOD_SERVICE) as InputMethodManager)
+                                .showInputMethodPicker()
+                        },
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
+                        Text("Switch Default Keyboard")
+                    }
+                }
+            }
+
+            Card(modifier = Modifier.fillMaxWidth()) {
+                Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    Text("Using the Keyboard", style = MaterialTheme.typography.titleMedium)
+                    Text(
+                        "Switch layout — Tap the QQ / ҚҚ button in the bottom-left corner to toggle " +
+                            "between Latin and Cyrillic scripts.\n\n" +
+                            "Shift — Tap once for one uppercase letter. Double-tap to enable Caps Lock. " +
+                            "Tap again to turn Caps Lock off.\n\n" +
+                            "Numbers & symbols — Tap the 123 button. Tap ABC to return to letters.\n\n" +
+                            "Emoji — Tap the smiley face button to open the emoji panel.\n\n" +
+                            "Double-space — Automatically inserts a period followed by a space, " +
+                            "useful for ending sentences quickly.",
+                        style = MaterialTheme.typography.bodyMedium
+                    )
+                }
+            }
+
+            Card(modifier = Modifier.fillMaxWidth()) {
+                Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    Text("Tips", style = MaterialTheme.typography.titleMedium)
+                    Text(
+                        "• The keyboard remembers which layout (Latin or Cyrillic) you last used.\n\n" +
+                            "• The first letter of a new sentence is automatically capitalized.\n\n" +
+                            "• Hold Backspace to delete characters continuously.\n\n" +
+                            "• Recently used emojis appear in the Recent tab of the emoji panel.",
+                        style = MaterialTheme.typography.bodyMedium
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/com/shagalalab/qqkeyboard/ui/settings/HelpScreen.kt
+++ b/app/src/main/kotlin/com/shagalalab/qqkeyboard/ui/settings/HelpScreen.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import android.provider.Settings
 import android.view.inputmethod.InputMethodManager
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -41,7 +42,8 @@ fun HelpScreen(
                 IconButton(onClick = onBackClick) {
                     Icon(painterResource(R.drawable.arrow_back_24px), contentDescription = "Back")
                 }
-            }
+            },
+            windowInsets = WindowInsets(0)
         )
 
         Column(

--- a/app/src/main/kotlin/com/shagalalab/qqkeyboard/ui/settings/KeyboardSettingsScreen.kt
+++ b/app/src/main/kotlin/com/shagalalab/qqkeyboard/ui/settings/KeyboardSettingsScreen.kt
@@ -1,6 +1,7 @@
 package com.shagalalab.qqkeyboard.ui.settings
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -60,7 +61,8 @@ fun KeyboardSettingsScreen(
                 IconButton(onClick = onBackClick) {
                     Icon(painterResource(R.drawable.arrow_back_24px), contentDescription = "Back")
                 }
-            }
+            },
+            windowInsets = WindowInsets(0)
         )
 
         Column(


### PR DESCRIPTION
## Summary

- Adds `AboutScreen` composable showing app version, description, GitHub link, and feature list
- Adds `HelpScreen` composable with step-by-step keyboard setup guide and usage tips
- Replaces three empty TODO stubs in `MainActivity` with real navigation using a `Screen` enum
- Enables `buildConfig = true` in `build.gradle.kts` so `BuildConfig.VERSION_NAME` is accessible at runtime

## Test plan

- [ ] Tap "Keyboard Settings" → opens settings screen, back button returns to main
- [ ] Tap "About" → opens About screen with version number visible, GitHub button opens browser
- [ ] Tap "Help" → opens Help screen, setup buttons (Input Method Settings, Switch Keyboard) work
- [ ] All back buttons return to the main screen

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)