### PR TITLE
Add SettingsActivity and fix IME subtype declarations

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -23,6 +23,11 @@
             </intent-filter>
         </activity>
 
+        <activity
+            android:name=".SettingsActivity"
+            android:exported="true"
+            android:theme="@style/Theme.QqKeyboard" />
+
         <service
             android:name="com.shagalalab.qqkeyboard.keyboard.service.QqKeyboardService"
             android:exported="false"

--- a/app/src/main/kotlin/com/shagalalab/qqkeyboard/SettingsActivity.kt
+++ b/app/src/main/kotlin/com/shagalalab/qqkeyboard/SettingsActivity.kt
@@ -1,0 +1,27 @@
+package com.shagalalab.qqkeyboard
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.ui.Modifier
+import com.shagalalab.qqkeyboard.ui.settings.KeyboardSettingsScreen
+import com.shagalalab.qqkeyboard.ui.theme.QqKeyboardTheme
+
+class SettingsActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
+        setContent {
+            QqKeyboardTheme {
+                KeyboardSettingsScreen(
+                    onBackClick = { finish() },
+                    modifier = Modifier.windowInsetsPadding(WindowInsets.safeDrawing)
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -6,6 +6,8 @@
     <string name="about_keyboard">Klaviatura haqqında</string>
     <string name="help">Járdem</string>
     <string name="test_keyboard_here">Bul jerde klaviaturanı sınap kórseńiz boladı</string>
+    <string name="subtype_latin">Latin (QQ)</string>
+    <string name="subtype_cyrillic">Cyrillic (ҚҚ)</string>
     <string name="word_separators" translatable="false">.!?</string>
     <string name="no_recent_emojis">No recent emojis</string>
 </resources>

--- a/app/src/main/res/xml/method.xml
+++ b/app/src/main/res/xml/method.xml
@@ -1,4 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
-<input-method xmlns:android="http://schemas.android.com/apk/res/android">
-    <subtype android:imeSubtypeMode="keyboard" />
+<input-method xmlns:android="http://schemas.android.com/apk/res/android"
+    android:settingsActivity="com.shagalalab.qqkeyboard.SettingsActivity">
+
+    <subtype
+        android:name="@string/subtype_latin"
+        android:imeSubtypeLocale="kaa"
+        android:imeSubtypeMode="keyboard"
+        android:isAsciiCapable="true" />
+
+    <subtype
+        android:name="@string/subtype_cyrillic"
+        android:imeSubtypeLocale="kaa"
+        android:imeSubtypeMode="keyboard"
+        android:isAsciiCapable="false" />
+
 </input-method>


### PR DESCRIPTION
## Summary

- Adds `SettingsActivity` — a thin wrapper around `KeyboardSettingsScreen` used as the system-facing settings entry point (launched from Android Settings → Language & Input → gear icon)
- Registers `SettingsActivity` in `AndroidManifest.xml`
- Updates `method.xml` to point to `SettingsActivity` via `settingsActivity` and replaces the generic subtype with explicit Latin and Cyrillic subtypes for Karakalpak (`kaa`), including `isAsciiCapable` flags
- Adds `subtype_latin` and `subtype_cyrillic` string resources

## Test plan

- [x] Install the keyboard and enable it in system settings
- [x] Navigate to Settings → System → Language & Input → On-screen keyboard → QqKeyboard — tap the settings gear icon → should open `SettingsActivity` directly
- [x] Two subtypes ("Latin (QQ)" and "Cyrillic (ҚҚ)") should appear in the input method picker
- [x] Build passes with no errors

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)