### PR TITLE
Add custom keyboard theming system

### DIFF
--- a/app/src/main/kotlin/com/shagalalab/qqkeyboard/keyboard/compose/KeyButton.kt
+++ b/app/src/main/kotlin/com/shagalalab/qqkeyboard/keyboard/compose/KeyButton.kt
@@ -16,7 +16,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -35,6 +34,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.shagalalab.qqkeyboard.keyboard.model.KeyData
 import com.shagalalab.qqkeyboard.keyboard.model.KeyType
+import com.shagalalab.qqkeyboard.keyboard.theme.LocalKeyboardColors
 import com.shagalalab.qqkeyboard.keyboard.utils.kaaUppercase
 import kotlinx.coroutines.delay
 
@@ -55,8 +55,8 @@ fun KeyButton(
     var isLongPressing by remember { mutableStateOf(false) }
 
     val keyShape = RoundedCornerShape(6.dp)
+    val colors = LocalKeyboardColors.current
 
-    // Key colors based on type
     val (backgroundColor, borderColor, contentColor) = when {
         keyData.code == "SPACER" -> Triple(
             Color.Transparent,
@@ -64,24 +64,24 @@ fun KeyButton(
             Color.Transparent
         )
         isPressed -> Triple(
-            MaterialTheme.colorScheme.primary.copy(alpha = 0.3f),
-            MaterialTheme.colorScheme.primary,
-            MaterialTheme.colorScheme.onSurface
+            colors.pressedBackground,
+            colors.pressedBorder,
+            colors.keyContent
         )
         keyData.keyType == KeyType.MODIFIER && keyData.code == "SHIFT" && isShiftActive -> Triple(
-            MaterialTheme.colorScheme.primary,
-            MaterialTheme.colorScheme.primary,
-            MaterialTheme.colorScheme.onPrimary
+            colors.shiftActiveBackground,
+            colors.shiftActiveBackground,
+            colors.shiftActiveContent
         )
         keyData.keyType == KeyType.MODIFIER || keyData.keyType == KeyType.ACTION -> Triple(
-            MaterialTheme.colorScheme.secondaryContainer,
-            MaterialTheme.colorScheme.outline,
-            MaterialTheme.colorScheme.onSecondaryContainer
+            colors.modifierBackground,
+            colors.modifierBorder,
+            colors.modifierContent
         )
         else -> Triple(
-            MaterialTheme.colorScheme.surface,
-            MaterialTheme.colorScheme.outline,
-            MaterialTheme.colorScheme.onSurface
+            colors.keyBackground,
+            colors.keyBorder,
+            colors.keyContent
         )
     }
 

--- a/app/src/main/kotlin/com/shagalalab/qqkeyboard/keyboard/compose/QqKeyboard.kt
+++ b/app/src/main/kotlin/com/shagalalab/qqkeyboard/keyboard/compose/QqKeyboard.kt
@@ -10,13 +10,14 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.layout.windowInsetsBottomHeight
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.shagalalab.qqkeyboard.keyboard.data.KeyboardMappings
 import com.shagalalab.qqkeyboard.keyboard.model.KeyData
 import com.shagalalab.qqkeyboard.keyboard.model.KeyboardLayout
+import com.shagalalab.qqkeyboard.keyboard.theme.LocalKeyboardColors
 import com.shagalalab.qqkeyboard.keyboard.viewmodel.KeyboardViewModel
 
 @Composable
@@ -27,10 +28,12 @@ fun QqKeyboard(
     val keyboardState = viewModel.keyboardState
     val currentImeAction = viewModel.currentImeAction
 
+    CompositionLocalProvider(LocalKeyboardColors provides viewModel.currentTheme.colors) {
+    val colors = LocalKeyboardColors.current
     Column(
         modifier = modifier
             .fillMaxWidth()
-            .background(MaterialTheme.colorScheme.surfaceContainer)
+            .background(colors.keyboardBackground)
     ) {
         val keyboardLayout: List<List<KeyData>> = when (keyboardState.layout) {
             KeyboardLayout.LATIN -> KeyboardMappings.getLatinLayout(currentImeAction)
@@ -92,4 +95,5 @@ fun QqKeyboard(
 
         Spacer(Modifier.windowInsetsBottomHeight(WindowInsets.systemBars))
     }
+    } // CompositionLocalProvider
 }

--- a/app/src/main/kotlin/com/shagalalab/qqkeyboard/keyboard/theme/KeyboardTheme.kt
+++ b/app/src/main/kotlin/com/shagalalab/qqkeyboard/keyboard/theme/KeyboardTheme.kt
@@ -1,75 +1,103 @@
 package com.shagalalab.qqkeyboard.keyboard.theme
 
+import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.graphics.Color
-import androidx.compose.material3.ColorScheme
-import androidx.compose.material3.darkColorScheme
-import androidx.compose.material3.lightColorScheme
+
+data class KeyboardColors(
+    val keyboardBackground: Color,
+    val keyBackground: Color,
+    val keyBorder: Color,
+    val keyContent: Color,
+    val modifierBackground: Color,
+    val modifierBorder: Color,
+    val modifierContent: Color,
+    val pressedBackground: Color,
+    val pressedBorder: Color,
+    val shiftActiveBackground: Color,
+    val shiftActiveContent: Color,
+)
 
 data class KeyboardTheme(
     val name: String,
-    val colorScheme: ColorScheme,
-    val keyBackground: Color,
-    val keyBorder: Color,
-    val keyText: Color,
-    val modifierKeyBackground: Color,
-    val modifierKeyBorder: Color,
-    val modifierKeyText: Color,
-    val spaceKeyBackground: Color,
-    val layoutSwitchBackground: Color,
-    val pressedKeyBackground: Color,
-    val activeModifierBackground: Color
+    val colors: KeyboardColors,
 )
 
+val LocalKeyboardColors = staticCompositionLocalOf { KeyboardThemes.Light.colors }
+
 object KeyboardThemes {
+
     val Light = KeyboardTheme(
         name = "Light",
-        colorScheme = lightColorScheme(),
-        keyBackground = Color(0xFFFFFFFF),
-        keyBorder = Color(0xFFE0E0E0),
-        keyText = Color(0xFF000000),
-        modifierKeyBackground = Color(0xFFF5F5F5),
-        modifierKeyBorder = Color(0xFFBDBDBD),
-        modifierKeyText = Color(0xFF424242),
-        spaceKeyBackground = Color(0xFFF9F9F9),
-        layoutSwitchBackground = Color(0xFFE8F5E8),
-        pressedKeyBackground = Color(0xFFE3F2FD),
-        activeModifierBackground = Color(0xFF2196F3)
+        colors = KeyboardColors(
+            keyboardBackground = Color(0xFFEFF0F3),
+            keyBackground = Color(0xFFFFFFFF),
+            keyBorder = Color(0xFFD1D3D8),
+            keyContent = Color(0xFF1A1A1A),
+            modifierBackground = Color(0xFFD1D3D8),
+            modifierBorder = Color(0xFFB0B3BA),
+            modifierContent = Color(0xFF1A1A1A),
+            pressedBackground = Color(0xFFBBD3FA),
+            pressedBorder = Color(0xFF4A90D9),
+            shiftActiveBackground = Color(0xFF4A90D9),
+            shiftActiveContent = Color(0xFFFFFFFF),
+        )
     )
-    
+
     val Dark = KeyboardTheme(
         name = "Dark",
-        colorScheme = darkColorScheme(),
-        keyBackground = Color(0xFF2C2C2C),
-        keyBorder = Color(0xFF404040),
-        keyText = Color(0xFFFFFFFF),
-        modifierKeyBackground = Color(0xFF363636),
-        modifierKeyBorder = Color(0xFF505050),
-        modifierKeyText = Color(0xFFE0E0E0),
-        spaceKeyBackground = Color(0xFF242424),
-        layoutSwitchBackground = Color(0xFF1B4B1B),
-        pressedKeyBackground = Color(0xFF1976D2),
-        activeModifierBackground = Color(0xFF1976D2)
+        colors = KeyboardColors(
+            keyboardBackground = Color(0xFF1C1C1E),
+            keyBackground = Color(0xFF2C2C2E),
+            keyBorder = Color(0xFF3A3A3C),
+            keyContent = Color(0xFFE8E8EA),
+            modifierBackground = Color(0xFF1C1C1E),
+            modifierBorder = Color(0xFF3A3A3C),
+            modifierContent = Color(0xFFAEAEB2),
+            pressedBackground = Color(0xFF1565C0),
+            pressedBorder = Color(0xFF1976D2),
+            shiftActiveBackground = Color(0xFF1976D2),
+            shiftActiveContent = Color(0xFFFFFFFF),
+        )
     )
-    
-    val KarakalpakBlue = KeyboardTheme(
-        name = "Karakalpak Blue",
-        colorScheme = lightColorScheme(
-            primary = Color(0xFF0066CC),
-            secondary = Color(0xFF4A90E2)
-        ),
-        keyBackground = Color(0xFFF8FAFF),
-        keyBorder = Color(0xFFD1E2FF),
-        keyText = Color(0xFF1A1A1A),
-        modifierKeyBackground = Color(0xFFE8F2FF),
-        modifierKeyBorder = Color(0xFF0066CC),
-        modifierKeyText = Color(0xFF0066CC),
-        spaceKeyBackground = Color(0xFFF0F7FF),
-        layoutSwitchBackground = Color(0xFFE0F0FF),
-        pressedKeyBackground = Color(0xFFB3D9FF),
-        activeModifierBackground = Color(0xFF0066CC)
+
+    val Amoled = KeyboardTheme(
+        name = "Amoled",
+        colors = KeyboardColors(
+            keyboardBackground = Color(0xFF000000),
+            keyBackground = Color(0xFF161616),
+            keyBorder = Color(0xFF242424),
+            keyContent = Color(0xFFFFFFFF),
+            modifierBackground = Color(0xFF0A0A0A),
+            modifierBorder = Color(0xFF242424),
+            modifierContent = Color(0xFFAAAAAA),
+            pressedBackground = Color(0xFF0D47A1),
+            pressedBorder = Color(0xFF1565C0),
+            shiftActiveBackground = Color(0xFF1565C0),
+            shiftActiveContent = Color(0xFFFFFFFF),
+        )
     )
-    
+
+    val Ocean = KeyboardTheme(
+        name = "Ocean",
+        colors = KeyboardColors(
+            keyboardBackground = Color(0xFF0D2137),
+            keyBackground = Color(0xFF15304D),
+            keyBorder = Color(0xFF1E4570),
+            keyContent = Color(0xFFCDE8FF),
+            modifierBackground = Color(0xFF0A1E30),
+            modifierBorder = Color(0xFF1E4570),
+            modifierContent = Color(0xFF8AB8D8),
+            pressedBackground = Color(0xFF005F9E),
+            pressedBorder = Color(0xFF0079C8),
+            shiftActiveBackground = Color(0xFF0079C8),
+            shiftActiveContent = Color(0xFFFFFFFF),
+        )
+    )
+
+    fun getByName(name: String): KeyboardTheme =
+        getAllThemes().firstOrNull { it.name == name } ?: Light
+
     fun getDefaultTheme(): KeyboardTheme = Light
-    
-    fun getAllThemes(): List<KeyboardTheme> = listOf(Light, Dark, KarakalpakBlue)
+
+    fun getAllThemes(): List<KeyboardTheme> = listOf(Light, Dark, Amoled, Ocean)
 }

--- a/app/src/main/kotlin/com/shagalalab/qqkeyboard/keyboard/viewmodel/KeyboardViewModel.kt
+++ b/app/src/main/kotlin/com/shagalalab/qqkeyboard/keyboard/viewmodel/KeyboardViewModel.kt
@@ -13,6 +13,8 @@ import com.shagalalab.qqkeyboard.keyboard.feedback.FeedbackManager
 import com.shagalalab.qqkeyboard.keyboard.model.KeyboardLayout
 import com.shagalalab.qqkeyboard.keyboard.model.KeyboardState
 import com.shagalalab.qqkeyboard.keyboard.preferences.KeyboardPreferences
+import com.shagalalab.qqkeyboard.keyboard.theme.KeyboardTheme
+import com.shagalalab.qqkeyboard.keyboard.theme.KeyboardThemes
 import com.shagalalab.qqkeyboard.keyboard.utils.EmojiUtils
 import com.shagalalab.qqkeyboard.keyboard.utils.kaaUppercase
 
@@ -28,6 +30,9 @@ class KeyboardViewModel : ViewModel() {
         private set
 
     var currentImeAction by mutableStateOf<Int?>(null)
+        private set
+
+    var currentTheme by mutableStateOf<KeyboardTheme>(KeyboardThemes.Light)
         private set
 
     private var inputConnection: InputConnection? = null
@@ -48,9 +53,10 @@ class KeyboardViewModel : ViewModel() {
             recentEmojis = preferences?.recentEmojis ?: emptyList()
             wordSeparators = context.resources.getString(R.string.word_separators).toSet()
         }
-        // Load last used layout
+        // Reload per-session preferences (re-evaluated every time keyboard is shown)
         val lastLayout = preferences?.lastUsedLayout ?: KeyboardLayout.LATIN
         keyboardState = keyboardState.copy(layout = lastLayout)
+        currentTheme = KeyboardThemes.getByName(preferences?.selectedTheme ?: "Light")
     }
 
     fun setInputConnection(connection: InputConnection?) {


### PR DESCRIPTION
## Summary

- Removes MaterialTheme dependency from keyboard rendering — `KeyButton` and `QqKeyboard` no longer use `MaterialTheme.colorScheme` at all
- Introduces `KeyboardColors` data class with 11 semantic color slots covering every visual state the keyboard uses
- `KeyboardTheme` wraps a name + `KeyboardColors` — adding a new theme is just one new object
- Colors are provided via `staticCompositionLocalOf` (`LocalKeyboardColors`) set up in `QqKeyboard` from `viewModel.currentTheme`
- `KeyboardViewModel` exposes `currentTheme` and reloads it from preferences each time `initialize()` is called (i.e. every time the keyboard is shown), so settings changes take effect on the next keyboard open
- Four predefined themes: **Light**, **Dark**, **Amoled** (true black), **Ocean** (dark blue)
- Settings UI and `KeyboardPreferences.selectedTheme` were already in place — this PR wires them up

## Test plan

- [ ] Open keyboard — verify Light theme looks correct (white keys, light gray modifier keys)
- [ ] Go to Settings → Change to Dark → open keyboard — verify dark theme applies
- [ ] Test Amoled (true black background) and Ocean (dark blue) themes
- [ ] Verify shift-active state (blue key) works in all themes
- [ ] Verify pressed state highlight works in all themes
- [ ] Verify emoji layout still renders correctly under each theme

🤖 Generated with [Claude Code](https://claude.com/claude-code)