### PR TITLE
Suppress haptic/sound feedback during backspace repeat

### DIFF
--- a/app/src/main/kotlin/com/shagalalab/qqkeyboard/keyboard/compose/KeyButton.kt
+++ b/app/src/main/kotlin/com/shagalalab/qqkeyboard/keyboard/compose/KeyButton.kt
@@ -54,6 +54,7 @@ fun KeyButton(
     onKeyClick: (String) -> Unit,
     modifier: Modifier = Modifier,
     onKeyLongPress: (() -> Unit)? = null,
+    onKeyRepeat: ((String) -> Unit)? = null,
     isShiftActive: Boolean = false
 ) {
     val interactionSource = remember { MutableInteractionSource() }
@@ -93,11 +94,12 @@ fun KeyButton(
         )
     }
 
-    // Handle repetitive long press for backspace
+    // Handle repetitive long press for backspace — uses onKeyRepeat (no feedback)
+    // so only the initial onClick vibration fires, matching standard keyboard behaviour.
     LaunchedEffect(isLongPressing) {
         if (isLongPressing && (keyData.code == "BACKSPACE")) {
             while (isLongPressing) {
-                onKeyClick(keyData.code)
+                (onKeyRepeat ?: onKeyClick)(keyData.code)
                 delay(REPEAT_INTERVAL_DELAY_MS)
             }
         }

--- a/app/src/main/kotlin/com/shagalalab/qqkeyboard/keyboard/compose/KeyRow.kt
+++ b/app/src/main/kotlin/com/shagalalab/qqkeyboard/keyboard/compose/KeyRow.kt
@@ -19,6 +19,7 @@ fun KeyRow(
     onKeyClick: (String) -> Unit,
     modifier: Modifier = Modifier,
     onKeyLongPress: ((String) -> Unit)? = null,
+    onKeyRepeat: ((String) -> Unit)? = null,
     isShiftActive: Boolean = false,
 ) {
     // Rows containing a space key fill the full width with weights (space expands to fill).
@@ -37,6 +38,7 @@ fun KeyRow(
             KeyButton(
                 keyData = keyData,
                 onKeyClick = onKeyClick,
+                onKeyRepeat = onKeyRepeat,
                 onKeyLongPress = if (onKeyLongPress != null) {
                     when {
                         keyData.code == "SHIFT" || keyData.code == "BACKSPACE" ->

--- a/app/src/main/kotlin/com/shagalalab/qqkeyboard/keyboard/compose/KeyboardLayout.kt
+++ b/app/src/main/kotlin/com/shagalalab/qqkeyboard/keyboard/compose/KeyboardLayout.kt
@@ -17,6 +17,7 @@ fun KeyboardLayout(
     modifier: Modifier = Modifier,
     onKeyClick: (String) -> Unit,
     onKeyLongPress: ((String) -> Unit)? = null,
+    onKeyRepeat: ((String) -> Unit)? = null,
     isShiftActive: Boolean = false,
 ) {
     BoxWithConstraints(modifier = modifier.fillMaxWidth()) {
@@ -35,6 +36,7 @@ fun KeyboardLayout(
                     standardKeyWidth = standardKeyWidth,
                     onKeyClick = onKeyClick,
                     onKeyLongPress = onKeyLongPress,
+                    onKeyRepeat = onKeyRepeat,
                     isShiftActive = isShiftActive,
                     modifier = Modifier.fillMaxWidth()
                 )

--- a/app/src/main/kotlin/com/shagalalab/qqkeyboard/keyboard/compose/QqKeyboard.kt
+++ b/app/src/main/kotlin/com/shagalalab/qqkeyboard/keyboard/compose/QqKeyboard.kt
@@ -80,6 +80,7 @@ fun QqKeyboard(
                 maxKeysInRow = maxKeysInRow,
                 modifier = Modifier.fillMaxWidth(),
                 onKeyClick = { key -> viewModel.onKeyPressed(key) },
+                onKeyRepeat = { viewModel.onBackspaceRepeat() },
                 onKeyLongPress = { key ->
                     when (key) {
                         "SHIFT" -> viewModel.onShiftLongPress()

--- a/app/src/main/kotlin/com/shagalalab/qqkeyboard/keyboard/viewmodel/KeyboardViewModel.kt
+++ b/app/src/main/kotlin/com/shagalalab/qqkeyboard/keyboard/viewmodel/KeyboardViewModel.kt
@@ -242,6 +242,21 @@ class KeyboardViewModel : ViewModel() {
         }
     }
 
+    fun onBackspaceRepeat() {
+        inputConnection?.let { ic ->
+            val selectedText = ic.getSelectedText(0)
+            if (selectedText != null && selectedText.isNotEmpty()) {
+                ic.commitText("", 1)
+            } else {
+                val textBefore = ic.getTextBeforeCursor(20, 0)?.toString()
+                val deleteLength = EmojiUtils.getGraphemeClusterLength(textBefore)
+                if (deleteLength > 0) {
+                    ic.deleteSurroundingText(deleteLength, 0)
+                }
+            }
+        }
+    }
+
     fun onShiftLongPress() {
         keyboardState = keyboardState.doubleTapShift()
     }


### PR DESCRIPTION
## Summary

- Long-pressing backspace now vibrates exactly once (on the initial tap) and deletes silently for all subsequent repeat deletions — matching standard keyboard behaviour
- Adds an `onKeyRepeat` callback threaded through `KeyButton → KeyRow → KeyboardLayout → QqKeyboard`; the repeat loop uses this instead of `onKeyClick`
- `ViewModel.onBackspaceRepeat()` performs the same smart deletion logic as the normal backspace path but without calling `feedbackManager`

## How it works

The initial `onClick` that fires before the long-press threshold is reached already plays one vibration via the normal `onKeyPressed` path. The `LaunchedEffect` repeat loop then uses `onKeyRepeat` (no feedback) for every subsequent deletion, giving the single-vibration-then-silent behaviour.

## Test plan

- [ ] Tap backspace briefly → one vibration, one character deleted
- [ ] Hold backspace → one vibration at start, then silent continuous deletion
- [ ] Smart deletion (emojis, multi-codepoint chars) still works correctly during repeat
- [ ] Selected text deletion still works during repeat

🤖 Generated with [Claude Code](https://claude.com/claude-code)