### PR TITLE
Reset emoji overlay on keyboard open

### DIFF
--- a/app/src/main/kotlin/com/shagalalab/qqkeyboard/keyboard/viewmodel/KeyboardViewModel.kt
+++ b/app/src/main/kotlin/com/shagalalab/qqkeyboard/keyboard/viewmodel/KeyboardViewModel.kt
@@ -59,7 +59,7 @@ class KeyboardViewModel : ViewModel() {
         }
         // Reload per-session preferences (re-evaluated every time keyboard is shown)
         val lastLayout = preferences?.lastUsedLayout ?: KeyboardLayout.LATIN
-        keyboardState = keyboardState.copy(layout = lastLayout)
+        keyboardState = keyboardState.copy(layout = lastLayout, isEmojiShown = false)
         currentTheme = KeyboardThemes.getByName(preferences?.selectedTheme ?: "Light")
         topRowMode = preferences?.topRowMode ?: TopRowMode.EXTRA_LETTERS
     }


### PR DESCRIPTION
## Summary

- Closing the keyboard while the emoji panel was open caused it to reappear on next show — `isEmojiShown` was persisted in the ViewModel across keyboard sessions but never cleared
- One-line fix: add `isEmojiShown = false` to the `keyboardState.copy()` call in `initialize()`, which already correctly restores the last Latin/Cyrillic layout

## Root cause

`KeyboardLayout.NUMERIC` and `KeyboardLayout.SYMBOLIC` were already handled correctly — `initialize()` overwrites `layout` with the saved Latin/Cyrillic preference. But `isEmojiShown` is a separate boolean on `KeyboardState` that `initialize()` didn't touch, so the emoji overlay survived across close/open cycles.

## Test plan

- [ ] Open emoji panel → close keyboard → reopen → starts with last Latin/Cyrillic layout, no emoji panel
- [ ] Switch to numeric layout → close → reopen → starts with last Latin/Cyrillic layout
- [ ] Normal Latin ↔ Cyrillic switching still persists correctly across close/open

🤖 Generated with [Claude Code](https://claude.com/claude-code)