### PR TITLE
Stage 3: Corpus-seeded bigram next-word prediction

### DIFF
--- a/app/src/main/kotlin/com/shagalalab/qqkeyboard/keyboard/compose/SuggestionStrip.kt
+++ b/app/src/main/kotlin/com/shagalalab/qqkeyboard/keyboard/compose/SuggestionStrip.kt
@@ -14,6 +14,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -54,6 +55,7 @@ fun SuggestionStrip(
                     .padding(horizontal = 8.dp, vertical = 10.dp),
                 color = colors.keyContent,
                 fontSize = 15.sp,
+                textAlign = TextAlign.Center,
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis,
             )

--- a/app/src/main/kotlin/com/shagalalab/qqkeyboard/keyboard/data/SuggestionRepository.kt
+++ b/app/src/main/kotlin/com/shagalalab/qqkeyboard/keyboard/data/SuggestionRepository.kt
@@ -29,7 +29,31 @@ class SuggestionRepository(context: Context) {
     }
 
     // Blocking — call from IO dispatcher
+    fun getBigramPredictions(lastWord: String, script: String, limit: Int = 5): List<String> {
+        if (lastWord.isEmpty()) return emptyList()
+
+        val seedResults = seed.queryBigrams(lastWord, script, 10)
+        val userResults = user.queryBigrams(lastWord, script, 10)
+
+        val scores = mutableMapOf<String, Int>()
+        seedResults.forEach { (word, freq) -> scores[word] = freq }
+        userResults.forEach { (word, freq) ->
+            scores[word] = (scores[word] ?: 0) + freq * 2
+        }
+
+        return scores.entries
+            .sortedByDescending { it.value }
+            .take(limit)
+            .map { it.key }
+    }
+
+    // Blocking — call from IO dispatcher
     fun learnWord(word: String, script: String) {
         user.learnWord(word, script)
+    }
+
+    // Blocking — call from IO dispatcher
+    fun learnBigram(prefix: String, nextWord: String, script: String) {
+        user.learnBigram(prefix, nextWord, script)
     }
 }

--- a/app/src/main/kotlin/com/shagalalab/qqkeyboard/keyboard/data/db/SeedDictionary.kt
+++ b/app/src/main/kotlin/com/shagalalab/qqkeyboard/keyboard/data/db/SeedDictionary.kt
@@ -36,4 +36,22 @@ class SeedDictionary(context: Context) {
         }
         return result
     }
+
+    fun queryBigrams(lastWord: String, script: String, limit: Int = 10): List<Pair<String, Int>> {
+        val database = db ?: return emptyList()
+        val result = mutableListOf<Pair<String, Int>>()
+        try {
+            database.rawQuery(
+                "SELECT next_word, frequency FROM bigrams WHERE prefix = ? AND script = ? ORDER BY frequency DESC LIMIT ?",
+                arrayOf(lastWord, script, limit.toString())
+            ).use { cursor ->
+                while (cursor.moveToNext()) {
+                    result.add(cursor.getString(0) to cursor.getInt(1))
+                }
+            }
+        } catch (_: Exception) {
+            // bigrams table absent in older seed.db — degrade gracefully
+        }
+        return result
+    }
 }

--- a/app/src/main/kotlin/com/shagalalab/qqkeyboard/keyboard/data/db/UserDictionary.kt
+++ b/app/src/main/kotlin/com/shagalalab/qqkeyboard/keyboard/data/db/UserDictionary.kt
@@ -5,7 +5,7 @@ import android.content.Context
 import android.database.sqlite.SQLiteDatabase
 import android.database.sqlite.SQLiteOpenHelper
 
-class UserDictionary(context: Context) : SQLiteOpenHelper(context, "user_words.db", null, 1) {
+class UserDictionary(context: Context) : SQLiteOpenHelper(context, "user_words.db", null, 2) {
 
     override fun onCreate(db: SQLiteDatabase) {
         db.execSQL(
@@ -20,15 +20,57 @@ class UserDictionary(context: Context) : SQLiteOpenHelper(context, "user_words.d
             """
         )
         db.execSQL("CREATE INDEX idx_user_word ON user_words(word, script)")
+        db.execSQL(
+            """
+            CREATE TABLE user_bigrams (
+                prefix    TEXT,
+                next_word TEXT,
+                script    TEXT,
+                frequency INTEGER DEFAULT 1,
+                last_used INTEGER,
+                PRIMARY KEY (prefix, next_word, script)
+            )
+            """
+        )
+        db.execSQL("CREATE INDEX idx_user_bigram ON user_bigrams(prefix, script)")
     }
 
-    override fun onUpgrade(db: SQLiteDatabase, oldVersion: Int, newVersion: Int) {}
+    override fun onUpgrade(db: SQLiteDatabase, oldVersion: Int, newVersion: Int) {
+        if (oldVersion < 2) {
+            db.execSQL(
+                """
+                CREATE TABLE IF NOT EXISTS user_bigrams (
+                    prefix    TEXT,
+                    next_word TEXT,
+                    script    TEXT,
+                    frequency INTEGER DEFAULT 1,
+                    last_used INTEGER,
+                    PRIMARY KEY (prefix, next_word, script)
+                )
+                """
+            )
+            db.execSQL("CREATE INDEX IF NOT EXISTS idx_user_bigram ON user_bigrams(prefix, script)")
+        }
+    }
 
     fun query(prefix: String, script: String, limit: Int = 10): List<Pair<String, Int>> {
         val result = mutableListOf<Pair<String, Int>>()
         readableDatabase.rawQuery(
             "SELECT word, frequency FROM user_words WHERE word LIKE ? AND script = ? ORDER BY frequency DESC LIMIT ?",
             arrayOf("$prefix%", script, limit.toString())
+        ).use { cursor ->
+            while (cursor.moveToNext()) {
+                result.add(cursor.getString(0) to cursor.getInt(1))
+            }
+        }
+        return result
+    }
+
+    fun queryBigrams(lastWord: String, script: String, limit: Int = 10): List<Pair<String, Int>> {
+        val result = mutableListOf<Pair<String, Int>>()
+        readableDatabase.rawQuery(
+            "SELECT next_word, frequency FROM user_bigrams WHERE prefix = ? AND script = ? ORDER BY frequency DESC LIMIT ?",
+            arrayOf(lastWord, script, limit.toString())
         ).use { cursor ->
             while (cursor.moveToNext()) {
                 result.add(cursor.getString(0) to cursor.getInt(1))
@@ -52,6 +94,26 @@ class UserDictionary(context: Context) : SQLiteOpenHelper(context, "user_words.d
             writableDatabase.execSQL(
                 "UPDATE user_words SET frequency = frequency + 1, last_used = ? WHERE word = ? AND script = ?",
                 arrayOf<Any>(now, word, script)
+            )
+        }
+    }
+
+    fun learnBigram(prefix: String, nextWord: String, script: String) {
+        val now = System.currentTimeMillis()
+        val cv = ContentValues().apply {
+            put("prefix", prefix)
+            put("next_word", nextWord)
+            put("script", script)
+            put("frequency", 1)
+            put("last_used", now)
+        }
+        val inserted = writableDatabase.insertWithOnConflict(
+            "user_bigrams", null, cv, SQLiteDatabase.CONFLICT_IGNORE
+        )
+        if (inserted == -1L) {
+            writableDatabase.execSQL(
+                "UPDATE user_bigrams SET frequency = frequency + 1, last_used = ? WHERE prefix = ? AND next_word = ? AND script = ?",
+                arrayOf<Any>(now, prefix, nextWord, script)
             )
         }
     }

--- a/app/src/main/kotlin/com/shagalalab/qqkeyboard/keyboard/viewmodel/KeyboardViewModel.kt
+++ b/app/src/main/kotlin/com/shagalalab/qqkeyboard/keyboard/viewmodel/KeyboardViewModel.kt
@@ -62,6 +62,7 @@ class KeyboardViewModel : ViewModel() {
 
     private var lastShiftTapTime: Long = 0L
     private var suggestionJob: Job? = null
+    private var lastCommittedWord: String = ""
 
     companion object {
         private const val DOUBLE_TAP_DELAY_MS = 300L
@@ -89,7 +90,10 @@ class KeyboardViewModel : ViewModel() {
 
     fun setInputConnection(connection: InputConnection?) {
         inputConnection = connection
-        if (connection == null) suggestions = emptyList()
+        if (connection == null) {
+            suggestions = emptyList()
+            lastCommittedWord = ""
+        }
     }
 
     fun setEditorInfo(info: EditorInfo?) {
@@ -121,6 +125,7 @@ class KeyboardViewModel : ViewModel() {
             }
         }
         updateShiftForCursor()
+        if (!isSuggestionsAllowed()) suggestions = emptyList()
     }
 
     fun onKeyPressed(key: String) {
@@ -164,9 +169,11 @@ class KeyboardViewModel : ViewModel() {
                         updateShiftForCursor()
                     }
                     feedbackManager?.playReturnFeedback()
+                    lastCommittedWord = ""
                     suggestions = emptyList()
                 }
                 "SPACE" -> {
+                    val committedWord = getCurrentWord()
                     learnCurrentWord()
                     val textBefore = ic.getTextBeforeCursor(1, 0)?.toString()
                     if ((preferences?.doubleSpacePeriodEnabled ?: true) && textBefore == " ") {
@@ -193,7 +200,12 @@ class KeyboardViewModel : ViewModel() {
                         updateShiftForCursor()
                     }
                     feedbackManager?.playSpacebarFeedback()
-                    suggestions = emptyList()
+                    if (committedWord.isNotEmpty()) {
+                        lastCommittedWord = committedWord
+                        updateSuggestions()
+                    } else {
+                        suggestions = emptyList()
+                    }
                 }
                 "SHIFT" -> {
                     val currentTime = System.currentTimeMillis()
@@ -264,8 +276,19 @@ class KeyboardViewModel : ViewModel() {
             }
             ic.commitText("$suggestion ", 1)
             feedbackManager?.playKeyPressFeedback()
-            suggestions = emptyList()
+
+            val prev = lastCommittedWord
+            val script = currentScript()
+            if (prev.isNotEmpty() && script != null) {
+                viewModelScope.launch(Dispatchers.IO) {
+                    repository?.learnWord(suggestion, script)
+                    repository?.learnBigram(prev, suggestion, script)
+                }
+            }
+
+            lastCommittedWord = suggestion
             updateShiftForCursor()
+            updateSuggestions()
         }
     }
 
@@ -295,6 +318,16 @@ class KeyboardViewModel : ViewModel() {
         keyboardState = keyboardState.toggleEmojiPopup()
     }
 
+    private fun isSuggestionsAllowed(): Boolean {
+        val info = editorInfo ?: return true
+        val variation = info.inputType and InputType.TYPE_MASK_VARIATION
+        if (variation == InputType.TYPE_TEXT_VARIATION_PASSWORD ||
+            variation == InputType.TYPE_TEXT_VARIATION_VISIBLE_PASSWORD ||
+            variation == InputType.TYPE_TEXT_VARIATION_WEB_PASSWORD) return false
+        if (info.imeOptions and EditorInfo.IME_FLAG_NO_PERSONALIZED_LEARNING != 0) return false
+        return true
+    }
+
     private fun getCurrentWord(): String {
         val text = inputConnection?.getTextBeforeCursor(100, 0)?.toString() ?: return ""
         return text.split(WORD_SPLIT_REGEX).lastOrNull() ?: ""
@@ -307,15 +340,22 @@ class KeyboardViewModel : ViewModel() {
     }
 
     private fun updateSuggestions() {
+        if (!isSuggestionsAllowed()) { suggestions = emptyList(); return }
         val script = currentScript() ?: run { suggestions = emptyList(); return }
         val word = getCurrentWord()
-        if (word.isEmpty()) { suggestions = emptyList(); return }
 
         suggestionJob?.cancel()
         suggestionJob = viewModelScope.launch {
-            delay(SUGGESTION_DEBOUNCE_MS)
-            val results = withContext(Dispatchers.IO) {
-                repository?.getSuggestions(word, script) ?: emptyList()
+            val results = if (word.isEmpty()) {
+                // No prefix being typed — show bigram predictions for last committed word
+                withContext(Dispatchers.IO) {
+                    repository?.getBigramPredictions(lastCommittedWord, script) ?: emptyList()
+                }
+            } else {
+                delay(SUGGESTION_DEBOUNCE_MS)
+                withContext(Dispatchers.IO) {
+                    repository?.getSuggestions(word, script) ?: emptyList()
+                }
             }
             suggestions = results
         }
@@ -325,14 +365,14 @@ class KeyboardViewModel : ViewModel() {
         val script = currentScript() ?: return
         val word = getCurrentWord()
         if (word.length < 3) return
+        if (!isSuggestionsAllowed()) return
 
-        val inputVariation = editorInfo?.inputType?.and(InputType.TYPE_MASK_VARIATION) ?: 0
-        if (inputVariation == InputType.TYPE_TEXT_VARIATION_PASSWORD ||
-            inputVariation == InputType.TYPE_TEXT_VARIATION_VISIBLE_PASSWORD) return
-        if ((editorInfo?.imeOptions ?: 0) and EditorInfo.IME_FLAG_NO_PERSONALIZED_LEARNING != 0) return
-
+        val prev = lastCommittedWord  // capture on main thread before launching coroutine
         viewModelScope.launch(Dispatchers.IO) {
             repository?.learnWord(word, script)
+            if (prev.isNotEmpty()) {
+                repository?.learnBigram(prev, word, script)
+            }
         }
     }
 

--- a/scripts/build_seed_db.py
+++ b/scripts/build_seed_db.py
@@ -197,34 +197,48 @@ def is_valid_word(word: str, script: str, min_len: int) -> bool:
 # Main pipeline
 # ---------------------------------------------------------------------------
 
-def collect_words(input_dir: Path, min_len: int) -> Counter:
+def collect_words(input_dir: Path, min_len: int) -> tuple[Counter, Counter]:
+    """Return (word_counts, bigram_counts). Invalid tokens act as sentence boundaries."""
     counts: Counter = Counter()
+    bigram_counts: Counter = Counter()
     files = [
         p for p in input_dir.rglob('*')
         if p.is_file() and p.suffix.lower() in EXTRACTORS
     ]
     if not files:
         print(f"No supported files found in {input_dir}")
-        return counts
+        return counts, bigram_counts
 
     print(f"Found {len(files)} file(s) to process")
     for path in files:
         text = extract_text(path)
         if not text:
             continue
+        prev_word: str | None = None
+        prev_script: str | None = None
         for raw_token in tokenize(text):
             word = normalize_word(raw_token)
             script = detect_script(word)
-            if script is None:
-                continue
-            if not is_valid_word(word, script, min_len):
+            if script is None or not is_valid_word(word, script, min_len):
+                prev_word = None
+                prev_script = None
                 continue
             counts[(word, script)] += 1
+            if prev_word is not None and prev_script == script:
+                bigram_counts[(prev_word, word, script)] += 1
+            prev_word = word
+            prev_script = script
 
-    return counts
+    return counts, bigram_counts
 
 
-def write_db(counts: Counter, output_path: Path, min_freq: int) -> None:
+def write_db(
+    counts: Counter,
+    bigram_counts: Counter,
+    output_path: Path,
+    min_freq: int,
+    min_bigram_freq: int,
+) -> None:
     output_path.parent.mkdir(parents=True, exist_ok=True)
 
     if output_path.exists():
@@ -243,25 +257,45 @@ def write_db(counts: Counter, output_path: Path, min_freq: int) -> None:
     """)
     cur.execute('CREATE INDEX idx_seed_word ON seed_words(word, script)')
 
-    rows = [
+    word_rows = [
         (word, script, freq)
         for (word, script), freq in counts.items()
         if freq >= min_freq
     ]
-    rows.sort(key=lambda r: r[2], reverse=True)
+    word_rows.sort(key=lambda r: r[2], reverse=True)
+    cur.executemany('INSERT INTO seed_words (word, script, frequency) VALUES (?, ?, ?)', word_rows)
 
+    cur.execute("""
+        CREATE TABLE bigrams (
+            prefix    TEXT,
+            next_word TEXT,
+            script    TEXT,
+            frequency INTEGER DEFAULT 1,
+            PRIMARY KEY (prefix, next_word, script)
+        )
+    """)
+    cur.execute('CREATE INDEX idx_bigram_prefix ON bigrams(prefix, script)')
+
+    bigram_rows = [
+        (prefix, next_word, script, freq)
+        for (prefix, next_word, script), freq in bigram_counts.items()
+        if freq >= min_bigram_freq
+    ]
     cur.executemany(
-        'INSERT INTO seed_words (word, script, frequency) VALUES (?, ?, ?)',
-        rows
+        'INSERT INTO bigrams (prefix, next_word, script, frequency) VALUES (?, ?, ?, ?)',
+        bigram_rows,
     )
+
     conn.commit()
     conn.close()
 
-    latin_count = sum(1 for _, s, _ in rows if s == 'latin')
-    cyrillic_count = sum(1 for _, s, _ in rows if s == 'cyrillic')
-    print(f"\nWrote {len(rows)} words to {output_path}")
-    print(f"  Latin:    {latin_count}")
-    print(f"  Cyrillic: {cyrillic_count}")
+    latin_words = sum(1 for _, s, _ in word_rows if s == 'latin')
+    cyrillic_words = sum(1 for _, s, _ in word_rows if s == 'cyrillic')
+    latin_bigrams = sum(1 for _, _, s, _ in bigram_rows if s == 'latin')
+    cyrillic_bigrams = sum(1 for _, _, s, _ in bigram_rows if s == 'cyrillic')
+    print(f"\nWrote {len(word_rows)} words and {len(bigram_rows)} bigrams to {output_path}")
+    print(f"  Words   — Latin: {latin_words}, Cyrillic: {cyrillic_words}")
+    print(f"  Bigrams — Latin: {latin_bigrams}, Cyrillic: {cyrillic_bigrams}")
 
 
 # ---------------------------------------------------------------------------
@@ -275,6 +309,7 @@ def main():
     parser.add_argument('--input', default='texts', help='Directory of source text files')
     parser.add_argument('--output', default=str(default_output), help='Output seed.db path')
     parser.add_argument('--min-freq', type=int, default=3, help='Minimum word frequency')
+    parser.add_argument('--min-bigram-freq', type=int, default=2, help='Minimum bigram frequency')
     parser.add_argument('--min-len', type=int, default=3, help='Minimum word length')
     args = parser.parse_args()
 
@@ -285,17 +320,18 @@ def main():
         print(f"Input directory not found: {input_dir}")
         return
 
-    print(f"Input:    {input_dir.resolve()}")
-    print(f"Output:   {output_path.resolve()}")
-    print(f"Min freq: {args.min_freq}")
-    print(f"Min len:  {args.min_len}\n")
+    print(f"Input:          {input_dir.resolve()}")
+    print(f"Output:         {output_path.resolve()}")
+    print(f"Min word freq:  {args.min_freq}")
+    print(f"Min bigram freq:{args.min_bigram_freq}")
+    print(f"Min len:        {args.min_len}\n")
 
-    counts = collect_words(input_dir, args.min_len)
+    counts, bigram_counts = collect_words(input_dir, args.min_len)
     if not counts:
         print("No words collected -- check your input files.")
         return
 
-    write_db(counts, output_path, args.min_freq)
+    write_db(counts, bigram_counts, output_path, args.min_freq, args.min_bigram_freq)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary

Adds bigram-based next-word prediction on top of the existing prefix autosuggestion. After the user commits a word (space or suggestion tap), the strip shows the most likely next words based on patterns learned from the Karakalpak corpus and the user's own typing history.

## Seed pipeline changes

- `collect_words` now returns `(word_counts, bigram_counts)` — consecutive valid word pairs are collected as bigrams
- Invalid tokens (numbers, foreign chars, punctuation) act as natural sentence boundaries so cross-sentence pairs are never recorded
- Both words in a pair must share the same script; Latin↔Cyrillic pairs are discarded
- New `bigrams(prefix, next_word, script, frequency)` table written into the same `seed.db`, indexed on `(prefix, script)`
- New `--min-bigram-freq` flag (default 2) — lower than words since bigrams are naturally less frequent

**Re-run the script** to regenerate `seed.db` with bigrams before testing.

## App changes

### Data layer
- **`SeedDictionary.queryBigrams`** — exact prefix lookup; wraps query in try/catch so older `seed.db` without the bigrams table degrades to empty results
- **`UserDictionary`** — schema v2: adds `user_bigrams` table; `onUpgrade` handles existing installs; `learnBigram` upserts with the same CONFLICT_IGNORE pattern as `learnWord`
- **`SuggestionRepository.getBigramPredictions`** — merges seed + user bigrams with `score = user_freq × 2 + seed_freq`

### ViewModel
- `lastCommittedWord` tracks the most recently committed word (reset on ENTER and field disconnect)
- `updateSuggestions` branches: `currentWord.isEmpty()` → bigram prediction for `lastCommittedWord`; `currentWord.isNotEmpty()` → prefix suggestions (debounced)
- `learnCurrentWord` captures `lastCommittedWord` on the main thread *before* launching the IO coroutine (avoids race with the SPACE handler that updates it)
- SPACE: saves the committed word to `lastCommittedWord`, then calls `updateSuggestions` to immediately show bigram predictions
- ENTER: resets `lastCommittedWord` (new sentence — previous context no longer relevant)
- `onSuggestionSelected`: learns the bigram (`prev → suggestion`), updates `lastCommittedWord = suggestion`, calls `updateSuggestions` to chain to the next prediction

## Test plan
- [x] Re-run `python build_seed_db.py` and verify bigrams table is present: `sqlite3 seed.db "SELECT COUNT(*) FROM bigrams;"`
- [x] Type a common word (e.g. `men`) and press space — strip should show likely next words
- [x] Tap a prediction — strip updates to show predictions for the tapped word
- [x] Type in a fresh word (not in corpus) and press space — strip shows empty or falls back gracefully
- [x] Type several sentences with the same word pairs — user bigrams should surface over time
- [x] Press enter mid-sentence — bigram context resets, strip clears

🤖 Generated with [Claude Code](https://claude.com/claude-code)