### PR TITLE
Add recency weighting to user dictionary scores

### DIFF
--- a/app/src/main/kotlin/com/shagalalab/qqkeyboard/keyboard/data/db/UserDictionary.kt
+++ b/app/src/main/kotlin/com/shagalalab/qqkeyboard/keyboard/data/db/UserDictionary.kt
@@ -7,6 +7,16 @@ import android.database.sqlite.SQLiteOpenHelper
 
 class UserDictionary(context: Context) : SQLiteOpenHelper(context, "user_words.db", null, 2) {
 
+    companion object {
+        private const val HALF_LIFE_DAYS = 30.0
+    }
+
+    private fun decayedFrequency(frequency: Int, lastUsed: Long): Int {
+        val ageDays = (System.currentTimeMillis() - lastUsed) / 86_400_000.0
+        val decay = Math.pow(2.0, -ageDays / HALF_LIFE_DAYS)
+        return (frequency * decay).toInt()
+    }
+
     override fun onCreate(db: SQLiteDatabase) {
         db.execSQL(
             """
@@ -56,11 +66,11 @@ class UserDictionary(context: Context) : SQLiteOpenHelper(context, "user_words.d
     fun query(prefix: String, script: String, limit: Int = 10): List<Pair<String, Int>> {
         val result = mutableListOf<Pair<String, Int>>()
         readableDatabase.rawQuery(
-            "SELECT word, frequency FROM user_words WHERE word LIKE ? AND script = ? ORDER BY frequency DESC LIMIT ?",
+            "SELECT word, frequency, last_used FROM user_words WHERE word LIKE ? AND script = ? ORDER BY frequency DESC LIMIT ?",
             arrayOf("$prefix%", script, limit.toString())
         ).use { cursor ->
             while (cursor.moveToNext()) {
-                result.add(cursor.getString(0) to cursor.getInt(1))
+                result.add(cursor.getString(0) to decayedFrequency(cursor.getInt(1), cursor.getLong(2)))
             }
         }
         return result
@@ -72,11 +82,11 @@ class UserDictionary(context: Context) : SQLiteOpenHelper(context, "user_words.d
         val placeholders = prefixes.joinToString(" OR ") { "word LIKE ?" }
         val args = (prefixes.map { "$it%" } + listOf(script, limit.toString())).toTypedArray()
         readableDatabase.rawQuery(
-            "SELECT word, frequency FROM user_words WHERE ($placeholders) AND script = ? ORDER BY frequency DESC LIMIT ?",
+            "SELECT word, frequency, last_used FROM user_words WHERE ($placeholders) AND script = ? ORDER BY frequency DESC LIMIT ?",
             args
         ).use { cursor ->
             while (cursor.moveToNext()) {
-                result.add(cursor.getString(0) to cursor.getInt(1))
+                result.add(cursor.getString(0) to decayedFrequency(cursor.getInt(1), cursor.getLong(2)))
             }
         }
         return result


### PR DESCRIPTION
## Summary

- User word scores are now multiplied by an exponential decay factor before being merged with seed scores
- Half-life is 30 days: a word typed today scores at full weight, 30 days ago at 0.5×, 60 days ago at 0.25×
- `last_used` was already being written on every `learnWord()` call — no schema changes required
- Decay is applied in `UserDictionary.decayedFrequency()` before the result is returned, so `SuggestionRepository` and all callers are unchanged
- Applies to both exact prefix queries and fuzzy prefix queries

## Test plan

- [ ] Type a word several times, verify it ranks high in suggestions
- [ ] Words typed recently should rank above words with similar raw frequency but typed long ago
- [ ] Seed dictionary words (no `last_used`) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)