### PR TITLE
Hide suggestion strip when emoji panel is open

### DIFF
--- a/app/src/main/kotlin/com/shagalalab/qqkeyboard/keyboard/compose/QqKeyboard.kt
+++ b/app/src/main/kotlin/com/shagalalab/qqkeyboard/keyboard/compose/QqKeyboard.kt
@@ -43,7 +43,7 @@ fun QqKeyboard(
             .fillMaxWidth()
             .background(colors.keyboardBackground)
     ) {
-        if (keyboardState.layout == KeyboardLayout.LATIN || keyboardState.layout == KeyboardLayout.CYRILLIC) {
+        if ((keyboardState.layout == KeyboardLayout.LATIN || keyboardState.layout == KeyboardLayout.CYRILLIC) && !keyboardState.isEmojiShown) {
             SuggestionStrip(
                 suggestions = viewModel.suggestions,
                 onSuggestionClick = viewModel::onSuggestionSelected,


### PR DESCRIPTION
## Summary

- Suggestion strip is now hidden when the emoji panel is open
- One-line change: added `&& !keyboardState.isEmojiShown` to the existing layout condition in `QqKeyboard.kt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)