### PR TITLE
Preserve capitalization when selecting a suggestion

### DIFF
--- a/app/src/main/kotlin/com/shagalalab/qqkeyboard/keyboard/viewmodel/KeyboardViewModel.kt
+++ b/app/src/main/kotlin/com/shagalalab/qqkeyboard/keyboard/viewmodel/KeyboardViewModel.kt
@@ -274,7 +274,7 @@ class KeyboardViewModel : ViewModel() {
             if (currentWord.isNotEmpty()) {
                 ic.deleteSurroundingText(currentWord.length, 0)
             }
-            ic.commitText("$suggestion ", 1)
+            ic.commitText("${applyCapitalization(currentWord, suggestion)} ", 1)
             feedbackManager?.playKeyPressFeedback()
 
             val prev = lastCommittedWord
@@ -326,6 +326,20 @@ class KeyboardViewModel : ViewModel() {
             variation == InputType.TYPE_TEXT_VARIATION_WEB_PASSWORD) return false
         if (info.imeOptions and EditorInfo.IME_FLAG_NO_PERSONALIZED_LEARNING != 0) return false
         return true
+    }
+
+    private fun applyCapitalization(typed: String, suggestion: String): String {
+        val letters = typed.filter { it.isLetter() }
+        return when {
+            letters.isEmpty() -> when {
+                keyboardState.shiftState == ShiftState.CAPS_LOCK -> suggestion.uppercase()
+                keyboardState.shouldShowUpperCase -> suggestion.replaceFirstChar { it.uppercaseChar() }
+                else -> suggestion
+            }
+            letters.length > 1 && letters.all { it.isUpperCase() } -> suggestion.uppercase()
+            letters.first().isUpperCase() -> suggestion.replaceFirstChar { it.uppercaseChar() }
+            else -> suggestion
+        }
     }
 
     private fun getCurrentWord(): String {


### PR DESCRIPTION
## Summary

- When tapping a suggestion, the committed word now mirrors the capitalization of what the user typed
- `applyCapitalization(typed, suggestion)` covers three cases:
  - First letter uppercase (`"Ad"` → `"Adam"`)
  - All uppercase / caps lock (`"AD"` → `"ADAM"`)
  - Lowercase (`"ad"` → `"adam"`)
- For bigram predictions (no current word typed), falls back to the keyboard's current shift state

## Test plan

- [ ] Type `Ad` → suggestions shown lowercase → tap one → committed as `Adam`
- [ ] Enable caps lock, type `AD` → tap suggestion → committed as `ADAM`
- [ ] Type `ad` → tap suggestion → committed as `adam`
- [ ] Tap a bigram prediction at start of sentence (shift active) → committed capitalized

🤖 Generated with [Claude Code](https://claude.com/claude-code)