### PR TITLE
Reduce unnecessary Compose recompositions in keyboard UI

### DIFF
--- a/app/src/main/kotlin/com/shagalalab/qqkeyboard/keyboard/compose/EmojiLayout.kt
+++ b/app/src/main/kotlin/com/shagalalab/qqkeyboard/keyboard/compose/EmojiLayout.kt
@@ -24,6 +24,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -50,7 +51,8 @@ fun EmojiLayout(
     onCloseEmojiLayout: () -> Unit,
     recentEmojis: List<String> = emptyList()
 ) {
-    val categories = EmojiData.getEmojisWithCategories(recentEmojis).keys.toList()
+    val emojiMap = remember(recentEmojis) { EmojiData.getEmojisWithCategories(recentEmojis) }
+    val categories = remember(emojiMap) { emojiMap.keys.toList() }
     val pagerState = rememberPagerState(pageCount = { categories.size })
     val coroutineScope = rememberCoroutineScope()
     val colors = LocalKeyboardColors.current
@@ -117,7 +119,7 @@ fun EmojiLayout(
             modifier = Modifier.fillMaxSize()
         ) { page ->
             val categoryIcon = categories[page]
-            val emojis = EmojiData.getEmojisWithCategories(recentEmojis)[categoryIcon] ?: emptyList()
+            val emojis = emojiMap[categoryIcon] ?: emptyList()
 
             EmojiCategoryPage(
                 emojis = emojis,

--- a/app/src/main/kotlin/com/shagalalab/qqkeyboard/keyboard/compose/KeyButton.kt
+++ b/app/src/main/kotlin/com/shagalalab/qqkeyboard/keyboard/compose/KeyButton.kt
@@ -53,6 +53,7 @@ import kotlinx.coroutines.delay
 private const val REPEAT_INTERVAL_DELAY_MS = 50L
 private const val BUBBLE_DISMISS_MS = 500L
 private val BUBBLE_SHAPE = RoundedCornerShape(8.dp)
+private val KEY_SHAPE = RoundedCornerShape(6.dp)
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
@@ -71,7 +72,6 @@ fun KeyButton(
     var showBubble by remember { mutableStateOf(false) }
     var bubbleLabel by remember { mutableStateOf("") }
 
-    val keyShape = RoundedCornerShape(6.dp)
     val colors = LocalKeyboardColors.current
     val keyHeight = LocalKeyboardHeight.current.toDp()
     val keyBackgroundEnabled = LocalKeyboardBorderEnabled.current
@@ -151,7 +151,7 @@ fun KeyButton(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(horizontal = KeyboardDimensions.keyHorizontalPadding)
-                .clip(keyShape)
+                .clip(KEY_SHAPE)
                 .background(backgroundColor),
             contentAlignment = Alignment.Center
         ) {

--- a/app/src/main/kotlin/com/shagalalab/qqkeyboard/keyboard/compose/QqKeyboard.kt
+++ b/app/src/main/kotlin/com/shagalalab/qqkeyboard/keyboard/compose/QqKeyboard.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.layout.windowInsetsBottomHeight
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.shagalalab.qqkeyboard.keyboard.data.KeyboardMappings
@@ -47,17 +48,29 @@ fun QqKeyboard(
                 .background(colors.keyboardBackground)
         ) {
             val topRowMode = viewModel.topRowMode
-            val keyboardLayout: List<List<KeyData>> = when (keyboardState.layout) {
-                KeyboardLayout.LATIN -> KeyboardMappings.getLatinLayout(topRowMode, currentImeAction)
-                KeyboardLayout.CYRILLIC -> KeyboardMappings.getCyrillicLayout(topRowMode, currentImeAction)
-                KeyboardLayout.NUMERIC -> KeyboardMappings.getNumericLayout(currentImeAction)
-                KeyboardLayout.SYMBOLIC -> KeyboardMappings.getSymbolicLayout(currentImeAction)
-                KeyboardLayout.NUMBER_PAD -> KeyboardMappings.getNumberPadLayout(currentImeAction)
-                KeyboardLayout.NUMBER_PASSWORD -> KeyboardMappings.getNumberPasswordLayout(currentImeAction)
-                KeyboardLayout.PHONE -> KeyboardMappings.getPhoneLayout(currentImeAction)
+            val switchButtonText = viewModel.getLayoutSwitchButtonText()
+            val updatedLayout = remember(keyboardState.layout, topRowMode, currentImeAction, switchButtonText) {
+                val baseLayout = when (keyboardState.layout) {
+                    KeyboardLayout.LATIN -> KeyboardMappings.getLatinLayout(topRowMode, currentImeAction)
+                    KeyboardLayout.CYRILLIC -> KeyboardMappings.getCyrillicLayout(topRowMode, currentImeAction)
+                    KeyboardLayout.NUMERIC -> KeyboardMappings.getNumericLayout(currentImeAction)
+                    KeyboardLayout.SYMBOLIC -> KeyboardMappings.getSymbolicLayout(currentImeAction)
+                    KeyboardLayout.NUMBER_PAD -> KeyboardMappings.getNumberPadLayout(currentImeAction)
+                    KeyboardLayout.NUMBER_PASSWORD -> KeyboardMappings.getNumberPasswordLayout(currentImeAction)
+                    KeyboardLayout.PHONE -> KeyboardMappings.getPhoneLayout(currentImeAction)
+                }
+                baseLayout.map { row ->
+                    row.map { keyData ->
+                        when (keyData.code) {
+                            "LAYOUT_SWITCH" -> keyData.copy(displayText = switchButtonText)
+                            "123", "ABC", "€~\\" -> keyData.copy(displayText = keyData.code)
+                            else -> keyData
+                        }
+                    }
+                }
             }
 
-            val numRows = keyboardLayout.size
+            val numRows = updatedLayout.size
             val maxKeysInRow = when (keyboardState.layout) {
                 KeyboardLayout.CYRILLIC -> 11
                 KeyboardLayout.NUMBER_PAD, KeyboardLayout.NUMBER_PASSWORD, KeyboardLayout.PHONE -> 4
@@ -88,22 +101,6 @@ fun QqKeyboard(
                             .height(keyAreaHeight)
                             .padding(KeyboardDimensions.gridPadding)
                     ) {
-                        val updatedLayout: List<List<KeyData>> = keyboardLayout.map { row ->
-                            row.map { keyData ->
-                                when (keyData.code) {
-                                    "LAYOUT_SWITCH" -> keyData.copy(
-                                        displayText = viewModel.getLayoutSwitchButtonText()
-                                    )
-
-                                    "123", "ABC", "€~\\" -> keyData.copy(
-                                        displayText = keyData.code
-                                    )
-
-                                    else -> keyData
-                                }
-                            }
-                        }
-
                         KeyboardLayout(
                             rows = updatedLayout,
                             maxKeysInRow = maxKeysInRow,

--- a/app/src/main/kotlin/com/shagalalab/qqkeyboard/keyboard/model/KeyData.kt
+++ b/app/src/main/kotlin/com/shagalalab/qqkeyboard/keyboard/model/KeyData.kt
@@ -1,6 +1,7 @@
 package com.shagalalab.qqkeyboard.keyboard.model
 
 import android.view.inputmethod.EditorInfo
+import androidx.compose.runtime.Immutable
 import com.shagalalab.qqkeyboard.R
 
 enum class KeyType {
@@ -11,6 +12,7 @@ enum class KeyType {
     LAYOUT_SWITCH
 }
 
+@Immutable
 data class KeyData(
     val code: String,
     val displayText: String = "",


### PR DESCRIPTION
## Summary

- **`KeyButton`**: `RoundedCornerShape(6.dp)` was constructed inside the composable, allocating ~40 new shape objects per recompose. Hoisted to a file-level `KEY_SHAPE` constant alongside the existing `BUBBLE_SHAPE`.
- **`KeyData`**: The `alternativeChars: List<String>` field caused the Compose compiler to treat `KeyData` as unstable, blocking `KeyButton` from skipping when its key data and shift state were unchanged. Added `@Immutable` — all fields are `val` and instances are used as static mapping data that never mutates.
- **`QqKeyboard`**: `keyboardLayout.map { … }` ran on every recompose, creating a fresh `List<List<KeyData>>` with ~40 `copy()` calls each time. `QqKeyboard` recomposes on every shift change, suggestion update, and cursor move. Wrapped the mapping in `remember(keyboardState.layout, topRowMode, currentImeAction, switchButtonText)` so it only rebuilds when the layout structure actually changes.
- **`EmojiLayout`**: `EmojiData.getEmojisWithCategories(recentEmojis)` was called twice per render — once to derive the category list and again inside each pager page. The full emoji map is O(n) to build. Cached with `remember(recentEmojis)` and reused across both sites.

## What's NOT fixed (and why)

- **`BoxWithConstraints` in `KeyboardLayout`**: Uses `SubcomposeLayout` internally, which composes children during the measure phase rather than the composition phase. Removing it requires either a custom `Layout` composable or deriving key widths from `LocalConfiguration`. The change is safe but more invasive; worth doing in a separate pass once Macrobenchmark numbers exist to verify the delta.
- **`List<List<KeyData>>` / `List<KeyData>` parameters on `KeyboardLayout` and `KeyRow`**: Even with `@Immutable KeyData`, the `List<T>` wrapper is still treated as unstable by the Compose compiler, so those composables can't skip recomposition. The cleanest fix is adding `kotlinx-collections-immutable` and replacing `List<>` with `ImmutableList<>` at the parameter boundaries — that's the remaining biggest stability win.

## Test plan

- [x] Type several characters and confirm letter keys show upper/lowercase correctly on shift
- [x] Double-tap shift to engage caps lock, verify all keys update
- [x] Switch between Latin and Cyrillic layouts — LAYOUT_SWITCH button text updates correctly
- [x] Switch to numeric layout and back — layout renders correctly
- [x] Open emoji picker, scroll through categories, confirm emojis render and are tappable
- [x] Add a recent emoji, reopen picker, confirm Recent category shows it

🤖 Generated with [Claude Code](https://claude.com/claude-code)