### PR TITLE
Add setting to hide suggestion strip and fix layout height consistency

### DIFF
--- a/app/src/main/kotlin/com/shagalalab/qqkeyboard/keyboard/compose/QqKeyboard.kt
+++ b/app/src/main/kotlin/com/shagalalab/qqkeyboard/keyboard/compose/QqKeyboard.kt
@@ -77,9 +77,9 @@ fun QqKeyboard(
                 else -> 10
             }
 
-            val showSuggestionStrip = (keyboardState.layout == KeyboardLayout.LATIN || keyboardState.layout == KeyboardLayout.CYRILLIC) && !keyboardState.isEmojiShown
+            val showSuggestionStrip = viewModel.suggestionStripEnabled && !keyboardState.isEmojiShown
             val keyAreaHeight = keyHeight * numRows + KeyboardDimensions.rowGap * (numRows - 1) + KeyboardDimensions.gridPadding * 4
-            val totalHeight = keyAreaHeight + if (showSuggestionStrip || keyboardState.isEmojiShown) KeyboardDimensions.suggestionStripHeight else 0.dp
+            val totalHeight = keyAreaHeight + if (viewModel.suggestionStripEnabled) KeyboardDimensions.suggestionStripHeight else 0.dp
 
             Box(
                 Modifier

--- a/app/src/main/kotlin/com/shagalalab/qqkeyboard/keyboard/preferences/KeyboardPreferences.kt
+++ b/app/src/main/kotlin/com/shagalalab/qqkeyboard/keyboard/preferences/KeyboardPreferences.kt
@@ -95,6 +95,10 @@ class KeyboardPreferences(context: Context) {
         get() = prefs.getBoolean(KEY_KEY_BORDER, true)
         set(value) { prefs.edit { putBoolean(KEY_KEY_BORDER, value) } }
 
+    var suggestionStripEnabled: Boolean
+        get() = prefs.getBoolean(KEY_SUGGESTION_STRIP, true)
+        set(value) { prefs.edit { putBoolean(KEY_SUGGESTION_STRIP, value) } }
+
     var vibrationStrength: VibrationStrength
         get() {
             val name = prefs.getString(KEY_VIBRATION_STRENGTH, VibrationStrength.MEDIUM.name)
@@ -151,6 +155,7 @@ class KeyboardPreferences(context: Context) {
         private const val KEY_KEYBOARD_HEIGHT = "keyboard_height"
         private const val KEY_KEY_BORDER = "key_border_enabled"
         private const val KEY_VIBRATION_STRENGTH = "vibration_strength"
+        private const val KEY_SUGGESTION_STRIP = "suggestion_strip_enabled"
         private const val MAX_RECENT_EMOJIS = COLLECTION_GRID_COLS_SIZE * 5
     }
 }

--- a/app/src/main/kotlin/com/shagalalab/qqkeyboard/keyboard/viewmodel/KeyboardViewModel.kt
+++ b/app/src/main/kotlin/com/shagalalab/qqkeyboard/keyboard/viewmodel/KeyboardViewModel.kt
@@ -54,6 +54,9 @@ class KeyboardViewModel : ViewModel() {
     var keyBorderEnabled by mutableStateOf(true)
         private set
 
+    var suggestionStripEnabled by mutableStateOf(true)
+        private set
+
     var suggestions by mutableStateOf<List<String>>(emptyList())
         private set
 
@@ -93,6 +96,7 @@ class KeyboardViewModel : ViewModel() {
         topRowMode = preferences?.topRowMode ?: TopRowMode.EXTRA_LETTERS
         keyboardHeight = preferences?.keyboardHeight ?: KeyboardHeight.DEFAULT
         keyBorderEnabled = preferences?.keyBorderEnabled ?: true
+        suggestionStripEnabled = preferences?.suggestionStripEnabled ?: true
     }
 
     fun setInputConnection(connection: InputConnection?) {
@@ -235,7 +239,6 @@ class KeyboardViewModel : ViewModel() {
                 "123" -> {
                     switchToLayout(KeyboardLayout.NUMERIC)
                     feedbackManager?.playKeyPressFeedback()
-                    suggestions = emptyList()
                 }
                 "ABC" -> {
                     switchToLastLanguage()
@@ -249,7 +252,6 @@ class KeyboardViewModel : ViewModel() {
                 "€~\\" -> {
                     switchToLayout(KeyboardLayout.SYMBOLIC)
                     feedbackManager?.playKeyPressFeedback()
-                    suggestions = emptyList()
                 }
                 else -> {
                     val textToCommit = if (keyboardState.shouldShowUpperCase) {
@@ -336,6 +338,7 @@ class KeyboardViewModel : ViewModel() {
     }
 
     private fun isSuggestionsAllowed(): Boolean {
+        if (!suggestionStripEnabled) return false
         val info = editorInfo ?: return true
         val variation = info.inputType and InputType.TYPE_MASK_VARIATION
         if (variation == InputType.TYPE_TEXT_VARIATION_PASSWORD ||

--- a/app/src/main/kotlin/com/shagalalab/qqkeyboard/ui/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/shagalalab/qqkeyboard/ui/settings/SettingsScreen.kt
@@ -56,6 +56,7 @@ fun SettingsScreen(
     var autoSpaceAfterPunctuation by remember { mutableStateOf(preferences.autoSpaceAfterPunctuation) }
     var autoRemoveSpaceBeforePunctuation by remember { mutableStateOf(preferences.autoRemoveSpaceBeforePunctuation) }
     var doubleSpacePeriodEnabled by remember { mutableStateOf(preferences.doubleSpacePeriodEnabled) }
+    var suggestionStripEnabled by remember { mutableStateOf(preferences.suggestionStripEnabled) }
 
     Scaffold(
         topBar = {
@@ -137,7 +138,7 @@ fun SettingsScreen(
             Column(verticalArrangement = Arrangement.spacedBy(ListItemDefaults.SegmentedGap)) {
                 SegmentedListItem(
                     onClick = onThemeSelectionClick,
-                    shapes = ListItemDefaults.segmentedShapes(0, 4),
+                    shapes = ListItemDefaults.segmentedShapes(0, 5),
                     supportingContent = { Text(selectedTheme) },
                     trailingContent = {
                         Icon(painter = painterResource(R.drawable.chevron_right_24px), contentDescription = null)
@@ -147,8 +148,21 @@ fun SettingsScreen(
                     Text(stringResource(R.string.settings_theme))
                 }
                 SegmentedListItem(
+                    onClick = {
+                        suggestionStripEnabled = !suggestionStripEnabled
+                        preferences.suggestionStripEnabled = suggestionStripEnabled
+                    },
+                    shapes = ListItemDefaults.segmentedShapes(1, 5),
+                    trailingContent = {
+                        Switch(checked = suggestionStripEnabled, onCheckedChange = null)
+                    },
+                    colors = ListItemDefaults.colors(containerColor = MaterialTheme.colorScheme.secondaryContainer)
+                ) {
+                    Text(stringResource(R.string.settings_suggestion_strip))
+                }
+                SegmentedListItem(
                     onClick = onKeyboardHeightClick,
-                    shapes = ListItemDefaults.segmentedShapes(1, 4),
+                    shapes = ListItemDefaults.segmentedShapes(2, 5),
                     supportingContent = {
                         Text(
                             when (keyboardHeight) {
@@ -169,7 +183,7 @@ fun SettingsScreen(
                         keyBorderEnabled = !keyBorderEnabled
                         preferences.keyBorderEnabled = keyBorderEnabled
                     },
-                    shapes = ListItemDefaults.segmentedShapes(2, 4),
+                    shapes = ListItemDefaults.segmentedShapes(3, 5),
                     trailingContent = {
                         Switch(checked = keyBorderEnabled, onCheckedChange = null)
                     },
@@ -179,7 +193,7 @@ fun SettingsScreen(
                 }
                 SegmentedListItem(
                     onClick = onTopRowModeClick,
-                    shapes = ListItemDefaults.segmentedShapes(3, 4),
+                    shapes = ListItemDefaults.segmentedShapes(4, 5),
                     supportingContent = {
                         Text(
                             when (topRowMode) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -47,6 +47,7 @@
     <string name="settings_auto_space">Auto-space after punctuation</string>
     <string name="settings_auto_remove_space">Auto-remove space before punctuation</string>
     <string name="settings_double_space_period">Double-space to period</string>
+    <string name="settings_suggestion_strip">Suggestions</string>
     <string name="settings_theme">Theme</string>
     <string name="settings_keyboard_height">Keyboard height</string>
     <string name="settings_preview">Preview</string>


### PR DESCRIPTION
## Summary

- **New setting** — "Suggestions" toggle in Settings → Appearance (below Theme). When off, the strip is hidden and all suggestion DB lookups stop entirely (`isSuggestionsAllowed()` returns false early).
- **No height jump** — when suggestions are enabled, the strip height is always reserved regardless of layout (`totalHeight = keyAreaHeight + suggestionStripHeight`). Previously the keyboard shrank by 40dp when switching from alphabetic to numeric, causing a visible jump.
- **Suggestions persist on layout switch** — switching to numeric/symbolic no longer clears the strip, so the word being typed remains visible and actionable. The strip clears naturally after the first key press in the new layout (no matching script → `updateSuggestions()` sets empty).
- **Emoji layout respects the setting** — when the strip is disabled, the keyboard stays at `keyAreaHeight` even when the emoji panel is open (no height jump on emoji toggle either).

## Test plan

- [ ] Toggle "Suggestions" off in settings — strip disappears and keyboard is shorter
- [ ] Toggle back on — strip reappears at correct height
- [ ] Type a word on Latin layout, press 123 — suggestions from the word are still visible on the numeric layout
- [ ] Press a number key — strip clears
- [ ] Press ABC — strip refreshes with suggestions for current context
- [ ] Switch Latin ↔ Cyrillic ↔ Numeric — no height jump when suggestions are enabled
- [ ] Open/close emoji panel — no height jump when suggestions are disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)