### PR TITLE
Open keyboard picker on long-press of space

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -12,7 +12,7 @@ android {
         applicationId = "com.shagalalab.qqkeyboard"
         minSdk = 26
         targetSdk = 37
-        versionCode = 25
+        versionCode = 26
         versionName = "1.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/app/src/main/kotlin/com/shagalalab/qqkeyboard/keyboard/compose/KeyRow.kt
+++ b/app/src/main/kotlin/com/shagalalab/qqkeyboard/keyboard/compose/KeyRow.kt
@@ -44,7 +44,7 @@ fun KeyRow(
                 onKeyRepeat = onKeyRepeat,
                 onKeyLongPress = if (onKeyLongPress != null) {
                     when {
-                        keyData.code == "SHIFT" || keyData.code == "BACKSPACE" ->
+                        keyData.code == "SHIFT" || keyData.code == "BACKSPACE" || keyData.code == "SPACE" ->
                             { { onKeyLongPress(keyData.code) } }
                         keyData.longPressCode != null ->
                             { { onKeyLongPress(keyData.longPressCode) } }

--- a/app/src/main/kotlin/com/shagalalab/qqkeyboard/keyboard/compose/QqKeyboard.kt
+++ b/app/src/main/kotlin/com/shagalalab/qqkeyboard/keyboard/compose/QqKeyboard.kt
@@ -124,6 +124,7 @@ fun QqKeyboard(
                                 when (key) {
                                     "SHIFT" -> viewModel.onShiftLongPress()
                                     "BACKSPACE" -> viewModel.onBackspaceLongPress()
+                                    "SPACE" -> viewModel.onSpaceLongPress()
                                     else -> viewModel.onKeyPressed(key)
                                 }
                             },

--- a/app/src/main/kotlin/com/shagalalab/qqkeyboard/keyboard/service/QqKeyboardService.kt
+++ b/app/src/main/kotlin/com/shagalalab/qqkeyboard/keyboard/service/QqKeyboardService.kt
@@ -1,7 +1,9 @@
 package com.shagalalab.qqkeyboard.keyboard.service
 
+import android.content.Context
 import android.inputmethodservice.InputMethodService
 import android.view.View
+import android.view.inputmethod.InputMethodManager
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.AbstractComposeView
 import androidx.lifecycle.Lifecycle
@@ -35,6 +37,10 @@ class QqKeyboardService : InputMethodService(), LifecycleOwner, SavedStateRegist
         savedStateRegistryController.performRestore(null)
         handleLifecycleEvent(Lifecycle.Event.ON_CREATE)
         keyboardViewModel = KeyboardViewModel()
+        keyboardViewModel.onShowInputMethodPicker = {
+            val imm = getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
+            imm.showInputMethodPicker()
+        }
     }
 
     override fun onCreateInputView(): View {

--- a/app/src/main/kotlin/com/shagalalab/qqkeyboard/keyboard/viewmodel/KeyboardViewModel.kt
+++ b/app/src/main/kotlin/com/shagalalab/qqkeyboard/keyboard/viewmodel/KeyboardViewModel.kt
@@ -72,6 +72,9 @@ class KeyboardViewModel : ViewModel() {
     private var inputConnection: InputConnection? = null
     private var editorInfo: EditorInfo? = null
 
+    /** Set by the service; invoked to open the system input-method (keyboard) picker. */
+    var onShowInputMethodPicker: (() -> Unit)? = null
+
     private var lastShiftTapTime: Long = 0L
     private var suggestionJob: Job? = null
     private var lastCommittedWord: String = ""
@@ -370,6 +373,10 @@ class KeyboardViewModel : ViewModel() {
     }
 
     fun onBackspaceLongPress() {
+    }
+
+    fun onSpaceLongPress() {
+        onShowInputMethodPicker?.invoke()
     }
 
     fun toggleEmoji() {


### PR DESCRIPTION
## Summary
Long-pressing the space key now opens the system input-method (keyboard) picker, restoring a feature from the previous version of the app.

## Changes
- **`KeyboardViewModel`** — added an `onShowInputMethodPicker` callback (set by the service) and an `onSpaceLongPress()` method that invokes it.
- **`QqKeyboardService`** — wired the callback in `onCreate` to call `InputMethodManager.showInputMethodPicker()`.
- **`KeyRow`** — routed `SPACE` through the long-press handler.
- **`QqKeyboard`** — mapped the `SPACE` long-press to `viewModel.onSpaceLongPress()`.

A short tap on space still commits a space; only a long press opens the picker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)