### PR TITLE
Support multiple long-press alternates on one key

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -12,8 +12,8 @@ android {
         applicationId = "com.shagalalab.qqkeyboard"
         minSdk = 26
         targetSdk = 37
-        versionCode = 26
-        versionName = "1.0"
+        versionCode = 27
+        versionName = "1.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/kotlin/com/shagalalab/qqkeyboard/keyboard/compose/KeyButton.kt
+++ b/app/src/main/kotlin/com/shagalalab/qqkeyboard/keyboard/compose/KeyButton.kt
@@ -3,6 +3,8 @@ package com.shagalalab.qqkeyboard.keyboard.compose
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.layout.Arrangement
@@ -10,25 +12,32 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.PlatformTextStyle
 import androidx.compose.ui.text.TextStyle
@@ -36,6 +45,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.LineHeightStyle
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
 import com.shagalalab.qqkeyboard.R
@@ -49,12 +59,36 @@ import com.shagalalab.qqkeyboard.keyboard.theme.LocalKeyboardColors
 import com.shagalalab.qqkeyboard.keyboard.theme.LocalKeyboardHeight
 import com.shagalalab.qqkeyboard.keyboard.theme.toDp
 import com.shagalalab.qqkeyboard.keyboard.utils.kaaUppercase
+import kotlin.math.floor
 import kotlinx.coroutines.delay
 
 private const val REPEAT_INTERVAL_DELAY_MS = 50L
 private const val BUBBLE_DISMISS_MS = 500L
+private const val PICKER_CANCELLED = -1
 private val BUBBLE_SHAPE = RoundedCornerShape(KeyboardDimensions.bubbleCornerRadius)
+private val PICKER_CELL_SHAPE = RoundedCornerShape(KeyboardDimensions.bubbleCellCornerRadius)
 private val KEY_SHAPE = RoundedCornerShape(KeyboardDimensions.keyCornerRadius)
+private const val PICKER_HIGHLIGHT_ALPHA = 0.15f
+
+/**
+ * Maps the finger position (in key-local coordinates) onto a picker cell index, or
+ * [PICKER_CANCELLED] when the finger has been dragged clear of the picker.
+ *
+ * The picker is laid out so that its first cell is centred on the key, which puts the resting
+ * finger position squarely inside cell 0 — lifting without moving therefore always commits the
+ * first alternate.
+ */
+private fun resolveAlternateIndex(
+    position: Offset,
+    keySize: IntSize,
+    cellWidthPx: Float,
+    cancelSlopPx: Float,
+    count: Int
+): Int {
+    if (position.y > keySize.height + cancelSlopPx) return PICKER_CANCELLED
+    val firstCellLeft = keySize.width / 2f - cellWidthPx / 2f
+    return floor((position.x - firstCellLeft) / cellWidthPx).toInt().coerceIn(0, count - 1)
+}
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
@@ -62,8 +96,9 @@ fun KeyButton(
     keyData: KeyData,
     onKeyClick: (String) -> Unit,
     modifier: Modifier = Modifier,
-    onKeyLongPress: (() -> Unit)? = null,
+    onKeyLongPress: ((String) -> Unit)? = null,
     onKeyRepeat: ((String) -> Unit)? = null,
+    onAlternateHighlight: (() -> Unit)? = null,
     shiftState: ShiftState = ShiftState.OFF,
     topTouchPadding: Dp = 0.dp,
     bottomTouchPadding: Dp = 0.dp
@@ -74,6 +109,14 @@ fun KeyButton(
     var isLongPressing by remember { mutableStateOf(false) }
     var showBubble by remember { mutableStateOf(false) }
     var bubbleLabel by remember { mutableStateOf("") }
+
+    val alternates = keyData.alternativeChars
+    // A single alternate commits on long press; several need the user to pick between them.
+    val hasPicker = alternates.size > 1
+    var isPickerOpen by remember { mutableStateOf(false) }
+    var highlightedIndex by remember { mutableIntStateOf(0) }
+    val currentLongPress by rememberUpdatedState(onKeyLongPress)
+    val currentHighlightFeedback by rememberUpdatedState(onAlternateHighlight)
 
     val colors = LocalKeyboardColors.current
     val keyHeight = LocalKeyboardHeight.current.toDp()
@@ -123,6 +166,38 @@ fun KeyButton(
         }
     }
 
+    // Keys with a picker need the finger tracked after the long press fires, which
+    // combinedClickable cannot do. This observer runs alongside it: it never consumes anything,
+    // so the click/long-click detection above is left exactly as it is for every other key.
+    val pickerModifier = if (hasPicker) {
+        Modifier.pointerInput(alternates) {
+            val cellWidthPx = KeyboardDimensions.bubbleCellWidth.toPx()
+            val cancelSlopPx = KeyboardDimensions.bubbleCancelSlop.toPx()
+            awaitEachGesture {
+                val down = awaitFirstDown(requireUnconsumed = false)
+                var index = 0
+                highlightedIndex = 0
+                while (true) {
+                    val event = awaitPointerEvent()
+                    val change = event.changes.firstOrNull { it.id == down.id } ?: break
+                    val resolved = resolveAlternateIndex(
+                        change.position, size, cellWidthPx, cancelSlopPx, alternates.size
+                    )
+                    if (resolved != index) {
+                        index = resolved
+                        highlightedIndex = resolved
+                        if (isPickerOpen) currentHighlightFeedback?.invoke()
+                    }
+                    if (!change.pressed) break
+                }
+                if (isPickerOpen) {
+                    isPickerOpen = false
+                    if (index != PICKER_CANCELLED) currentLongPress?.invoke(alternates[index])
+                }
+            }
+        }
+    } else Modifier
+
     // Outer box: full allocated width and height (including the inter-row gap absorbed via
     // top/bottomTouchPadding) — this is the touch target.
     // Inner box: inset by keyHorizontalPadding on each side and by the touch paddings top/bottom
@@ -139,17 +214,25 @@ fun KeyButton(
                         indication = null,
                         onClick = { onKeyClick(keyData.code) },
                         onLongClick = {
-                            if (keyData.code == "BACKSPACE") {
-                                isLongPressing = true
-                            } else {
-                                if (keyData.secondaryLabel != null) {
-                                    bubbleLabel = if (isShiftActive) keyData.secondaryLabel.kaaUppercase() else keyData.secondaryLabel
-                                    showBubble = true
+                            when {
+                                keyData.code == "BACKSPACE" -> isLongPressing = true
+                                // Nothing is committed yet — the picker waits for the release.
+                                // The tick stands in for the key press feedback the user would
+                                // otherwise have felt at this point.
+                                hasPicker -> {
+                                    isPickerOpen = true
+                                    onAlternateHighlight?.invoke()
                                 }
-                                onKeyLongPress?.invoke()
+                                else -> {
+                                    alternates.firstOrNull()?.let { alternate ->
+                                        bubbleLabel = if (isShiftActive) alternate.kaaUppercase() else alternate
+                                        showBubble = true
+                                    }
+                                    onKeyLongPress?.invoke(alternates.firstOrNull() ?: keyData.code)
+                                }
                             }
                         }
-                    )
+                    ).then(pickerModifier)
                 } else m
             }
     ) {
@@ -217,9 +300,9 @@ fun KeyButton(
                     )
                 }
             }
-            if (keyData.secondaryLabel != null) {
+            if (alternates.isNotEmpty()) {
                 Text(
-                    text = keyData.secondaryLabel,
+                    text = alternates.joinToString(" "),
                     modifier = Modifier
                         .align(Alignment.TopEnd)
                         .padding(end = KeyboardDimensions.secondaryLabelEndPadding, top = KeyboardDimensions.secondaryLabelTopPadding),
@@ -260,6 +343,54 @@ fun KeyButton(
                     fontWeight = FontWeight.Normal,
                     maxLines = 1
                 )
+            }
+        }
+
+        // Picker bubble: same placement trick as above, but shifted right by half a cell so the
+        // first cell — the default choice — sits directly over the key.
+        // unbounded = true is essential: without it the row is measured against the key's own
+        // width and every cell past the first is squeezed out. Centring the oversized row on the
+        // key and then shifting it by half a cell leaves the first cell exactly over the key,
+        // which is the geometry resolveAlternateIndex assumes.
+        if (isPickerOpen) {
+            Row(
+                modifier = Modifier
+                    .align(Alignment.TopCenter)
+                    .offset(
+                        x = KeyboardDimensions.bubbleCellWidth * (alternates.size - 1) / 2,
+                        y = -(keyHeight + KeyboardDimensions.bubbleVerticalOffset)
+                    )
+                    .zIndex(1f)
+                    .wrapContentWidth(align = Alignment.CenterHorizontally, unbounded = true)
+                    .height(keyHeight)
+                    .shadow(KeyboardDimensions.bubbleShadowElevation, BUBBLE_SHAPE)
+                    .background(colors.bubbleBackground, BUBBLE_SHAPE)
+            ) {
+                alternates.forEachIndexed { index, alternate ->
+                    Box(
+                        modifier = Modifier
+                            .width(KeyboardDimensions.bubbleCellWidth)
+                            .fillMaxHeight()
+                            .padding(KeyboardDimensions.bubbleCellInset)
+                            .clip(PICKER_CELL_SHAPE)
+                            .background(
+                                if (index == highlightedIndex) {
+                                    colors.keyContent.copy(alpha = PICKER_HIGHLIGHT_ALPHA)
+                                } else {
+                                    Color.Transparent
+                                }
+                            ),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Text(
+                            text = if (isShiftActive) alternate.kaaUppercase() else alternate,
+                            color = colors.keyContent,
+                            fontSize = if (isLandscape) KeyboardDimensions.bubbleFontSizeLandscape else KeyboardDimensions.bubbleFontSize,
+                            fontWeight = FontWeight.Normal,
+                            maxLines = 1
+                        )
+                    }
+                }
             }
         }
     }

--- a/app/src/main/kotlin/com/shagalalab/qqkeyboard/keyboard/compose/KeyRow.kt
+++ b/app/src/main/kotlin/com/shagalalab/qqkeyboard/keyboard/compose/KeyRow.kt
@@ -21,6 +21,7 @@ fun KeyRow(
     modifier: Modifier = Modifier,
     onKeyLongPress: ((String) -> Unit)? = null,
     onKeyRepeat: ((String) -> Unit)? = null,
+    onAlternateHighlight: (() -> Unit)? = null,
     shiftState: ShiftState = ShiftState.OFF,
     topTouchPadding: Dp = 0.dp,
     bottomTouchPadding: Dp = 0.dp,
@@ -42,15 +43,15 @@ fun KeyRow(
                 keyData = keyData,
                 onKeyClick = onKeyClick,
                 onKeyRepeat = onKeyRepeat,
-                onKeyLongPress = if (onKeyLongPress != null) {
-                    when {
-                        keyData.code == "SHIFT" || keyData.code == "BACKSPACE" || keyData.code == "SPACE" ->
-                            { { onKeyLongPress(keyData.code) } }
-                        keyData.longPressCode != null ->
-                            { { onKeyLongPress(keyData.longPressCode) } }
-                        else -> null
-                    }
-                } else null,
+                // KeyButton decides what a long press resolves to (the key's own code for
+                // modifiers, or the chosen alternate) and passes it back through this callback.
+                onKeyLongPress = when {
+                    onKeyLongPress == null -> null
+                    keyData.code == "SHIFT" || keyData.code == "BACKSPACE" || keyData.code == "SPACE" -> onKeyLongPress
+                    keyData.alternativeChars.isNotEmpty() -> onKeyLongPress
+                    else -> null
+                },
+                onAlternateHighlight = onAlternateHighlight,
                 shiftState = shiftState,
                 topTouchPadding = topTouchPadding,
                 bottomTouchPadding = bottomTouchPadding,

--- a/app/src/main/kotlin/com/shagalalab/qqkeyboard/keyboard/compose/KeyboardLayout.kt
+++ b/app/src/main/kotlin/com/shagalalab/qqkeyboard/keyboard/compose/KeyboardLayout.kt
@@ -22,6 +22,7 @@ fun KeyboardLayout(
     onKeyClick: (String) -> Unit,
     onKeyLongPress: ((String) -> Unit)? = null,
     onKeyRepeat: ((String) -> Unit)? = null,
+    onAlternateHighlight: (() -> Unit)? = null,
     shiftState: ShiftState = ShiftState.OFF,
 ) {
     BoxWithConstraints(modifier = modifier.fillMaxWidth()) {
@@ -42,6 +43,7 @@ fun KeyboardLayout(
                     onKeyClick = onKeyClick,
                     onKeyLongPress = onKeyLongPress,
                     onKeyRepeat = onKeyRepeat,
+                    onAlternateHighlight = onAlternateHighlight,
                     shiftState = shiftState,
                     topTouchPadding = if (index == 0) 0.dp else halfGap,
                     bottomTouchPadding = if (index == rows.lastIndex) 0.dp else halfGap,

--- a/app/src/main/kotlin/com/shagalalab/qqkeyboard/keyboard/compose/QqKeyboard.kt
+++ b/app/src/main/kotlin/com/shagalalab/qqkeyboard/keyboard/compose/QqKeyboard.kt
@@ -128,6 +128,7 @@ fun QqKeyboard(
                                     else -> viewModel.onKeyPressed(key)
                                 }
                             },
+                            onAlternateHighlight = viewModel::onAlternateHighlight,
                             shiftState = keyboardState.shiftState,
                         )
                     }

--- a/app/src/main/kotlin/com/shagalalab/qqkeyboard/keyboard/data/KeyboardMappings.kt
+++ b/app/src/main/kotlin/com/shagalalab/qqkeyboard/keyboard/data/KeyboardMappings.kt
@@ -71,17 +71,23 @@ object KeyboardMappings {
         )
     }
 
-    private fun latinSecondary(base: String, extra: String, mode: TopRowMode): KeyData {
+    private fun latinSecondary(base: String, extra: String, mode: TopRowMode): KeyData =
+        latinSecondary(base, listOf(extra), mode)
+
+    private fun latinSecondary(base: String, extras: List<String>, mode: TopRowMode): KeyData {
         return if (mode == TopRowMode.NUMBERS) {
-            KeyData.character(base).copy(longPressCode = extra, secondaryLabel = extra)
+            KeyData.character(base).copy(alternativeChars = extras)
         } else {
             KeyData.character(base)
         }
     }
 
-    private fun cyrillicSecondary(base: String, extra: String, mode: TopRowMode): KeyData {
+    private fun cyrillicSecondary(base: String, extra: String, mode: TopRowMode): KeyData =
+        cyrillicSecondary(base, listOf(extra), mode)
+
+    private fun cyrillicSecondary(base: String, extras: List<String>, mode: TopRowMode): KeyData {
         return if (mode == TopRowMode.NUMBERS) {
-            KeyData.character(base).copy(longPressCode = extra, secondaryLabel = extra)
+            KeyData.character(base).copy(alternativeChars = extras)
         } else {
             KeyData.character(base)
         }
@@ -107,9 +113,11 @@ object KeyboardMappings {
         return listOf(
             topRow,
             listOf(
-                cyrillicSecondary("й", "ў", topRowMode),
+                KeyData.character("й"),
                 KeyData.character("ц"),
-                cyrillicSecondary("у", "ү", topRowMode),
+                // ў and ү are both у-variants, so they share the у key rather than ў being
+                // parked on й for want of a phonetic base of its own.
+                cyrillicSecondary("у", listOf("ў", "ү"), topRowMode),
                 cyrillicSecondary("к", "қ", topRowMode),
                 cyrillicSecondary("е", "ё", topRowMode),
                 cyrillicSecondary("н", "ң", topRowMode),

--- a/app/src/main/kotlin/com/shagalalab/qqkeyboard/keyboard/model/KeyData.kt
+++ b/app/src/main/kotlin/com/shagalalab/qqkeyboard/keyboard/model/KeyData.kt
@@ -20,10 +20,10 @@ data class KeyData(
     val iconResId: Int? = null,
     val widthRatio: Float = 1f,
     val fillSpace: Boolean = false,
-    val longPressCode: String? = null,
+    // Characters reachable by long-pressing this key. A single entry commits straight away on
+    // long press; two or more open a picker bubble the user slides across to choose from.
     val alternativeChars: List<String> = emptyList(),
     val hintText: String? = null,
-    val secondaryLabel: String? = null,
 ) {
     companion object {
         // Character keys

--- a/app/src/main/kotlin/com/shagalalab/qqkeyboard/keyboard/theme/KeyboardDimensions.kt
+++ b/app/src/main/kotlin/com/shagalalab/qqkeyboard/keyboard/theme/KeyboardDimensions.kt
@@ -48,6 +48,15 @@ object KeyboardDimensions {
     val bubbleShadowElevation = 6.dp
     val bubbleHorizontalPadding = 10.dp
 
+    // --- Alternate picker (long-press popup with more than one alternate) ---
+    // Cells are laid out at exactly bubbleCellWidth so the finger's x position maps directly
+    // onto a cell index; the inset is applied inside each cell to keep that mapping exact.
+    val bubbleCellWidth = 48.dp
+    val bubbleCellInset = 3.dp
+    val bubbleCellCornerRadius = 6.dp
+    // How far below the key the finger must travel to dismiss the picker without choosing.
+    val bubbleCancelSlop = 24.dp
+
     // --- Icons ---
     val actionIconSize = 24.dp
 

--- a/app/src/main/kotlin/com/shagalalab/qqkeyboard/keyboard/viewmodel/KeyboardViewModel.kt
+++ b/app/src/main/kotlin/com/shagalalab/qqkeyboard/keyboard/viewmodel/KeyboardViewModel.kt
@@ -379,6 +379,12 @@ class KeyboardViewModel : ViewModel() {
         onShowInputMethodPicker?.invoke()
     }
 
+    /** The highlight moved to another alternate in the long-press picker — vibrate only, since
+     * a key press sound on every crossing would be noisy. */
+    fun onAlternateHighlight() {
+        feedbackManager?.playKeyPressVibration()
+    }
+
     fun toggleEmoji() {
         val opening = !keyboardState.isEmojiShown
         keyboardState = keyboardState.toggleEmojiPopup()


### PR DESCRIPTION
Long press has so far been a fire-and-forget commit of a single alternate, which left `ў` with nowhere to go: every other secondary is a phonetic variant of the key it sits on (`у→ү`, `к→қ`, `н→ң`, ...), so `ў` ended up parked on `й` for want of a base of its own.

This gives `у` both of its variants — `ў` first, then `ү` — and hands `й` back to itself, restoring the behaviour the old version of the app had.

## Behaviour

A key with **two or more** alternates now opens a picker on long press. The first cell sits directly over the key, so the resting finger is already on the default:

| Gesture | Result |
|---|---|
| Hold `у`, release without moving | `ў` |
| Hold `у`, slide right one cell, release | `ү` |
| Hold `у`, drag below the key, release | nothing committed |
| Hold `к` (single alternate) | `қ` commits instantly, flash bubble — unchanged |
| Hold `й` | nothing — secondary removed |

Keys with a **single** alternate are untouched: long press still commits immediately and flashes the existing bubble.

Two consequences worth noting on review:
- For `у` only, the character now lands on lift rather than while the finger is still down, which also moves the haptic tick to lift time.
- `у` long-press now produces `ў` rather than `ү`, so it's a change in muscle memory for current users.

## Implementation

- `KeyData.longPressCode` and `secondaryLabel` collapse into the already-declared-but-unused `alternativeChars: List<String>`; both the key-face hint and the long-press target derive from it.
- `KeyboardMappings` gains a `List<String>` overload alongside the existing single-alternate one, so all 14 other call sites are untouched.
- `KeyButton` keeps `combinedClickable` for click and long-click detection — press state, timing and semantics are unchanged for every key. The picker adds a second `pointerInput` that only *observes* (never consumes), so it can track the finger after the long press fires, and it is attached only to keys that need it.
- Haptic ticks on picker open and on each highlight crossing route through a new `KeyboardViewModel.onAlternateHighlight()` so they respect the user's vibration-strength setting. Vibration only — a keypress sound on every crossing would be noisy.

The picker extends rightward past the key, which is fine for `у` (3rd of 11) but would run off-screen for a rightmost key. Putting two alternates on `х` or `ҳ` later would need edge clamping.

## Testing

Verified by hand on a Pixel 8a emulator (API 36) with the Cyrillic layout and numbers top row — all five rows of the table above. `./gradlew lintDebug` and `assembleDebug` pass. The project has no unit tests (`testDebugUnitTest` reports `NO-SOURCE`), so the device run is the verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)