### PR TITLE
Add setting to hide the suggestion strip

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -12,8 +12,8 @@ android {
         applicationId = "com.shagalalab.qqkeyboard"
         minSdk = 26
         targetSdk = 37
-        versionCode = 27
-        versionName = "1.1"
+        versionCode = 28
+        versionName = "1.2"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/kotlin/com/shagalalab/qqkeyboard/SettingsActivity.kt
+++ b/app/src/main/kotlin/com/shagalalab/qqkeyboard/SettingsActivity.kt
@@ -16,6 +16,8 @@ import com.shagalalab.qqkeyboard.ui.settings.HeightSelection
 import com.shagalalab.qqkeyboard.ui.settings.KeyboardHeightScreen
 import com.shagalalab.qqkeyboard.ui.settings.Settings
 import com.shagalalab.qqkeyboard.ui.settings.SettingsScreen
+import com.shagalalab.qqkeyboard.ui.settings.SuggestionStripScreen
+import com.shagalalab.qqkeyboard.ui.settings.SuggestionStripSelection
 import com.shagalalab.qqkeyboard.ui.settings.ThemeSelection
 import com.shagalalab.qqkeyboard.ui.settings.ThemeSelectionScreen
 import com.shagalalab.qqkeyboard.ui.settings.TopRowModeScreen
@@ -35,6 +37,7 @@ class SettingsActivity : ComponentActivity() {
                 var keyboardHeight by remember { mutableStateOf(preferences.keyboardHeight) }
                 var vibrationStrength by remember { mutableStateOf(preferences.vibrationStrength) }
                 var topRowMode by remember { mutableStateOf(preferences.topRowMode) }
+                var suggestionStripEnabled by remember { mutableStateOf(preferences.suggestionStripEnabled) }
 
                 NavDisplay(
                     backStack = backStack,
@@ -48,6 +51,8 @@ class SettingsActivity : ComponentActivity() {
                                 onKeyboardHeightClick = { backStack.add(HeightSelection) },
                                 vibrationStrength = vibrationStrength,
                                 onVibrationStrengthClick = { backStack.add(VibrationSelection) },
+                                suggestionStripEnabled = suggestionStripEnabled,
+                                onSuggestionStripClick = { backStack.add(SuggestionStripSelection) },
                                 topRowMode = topRowMode,
                                 onTopRowModeClick = { backStack.add(TopRowSelection) },
                             )
@@ -71,6 +76,17 @@ class SettingsActivity : ComponentActivity() {
                                 onSelect = { strength ->
                                     vibrationStrength = strength
                                     preferences.vibrationStrength = strength
+                                },
+                                onBackClick = { backStack.removeLastOrNull() },
+                            )
+                        }
+                        entry<SuggestionStripSelection> {
+                            SuggestionStripScreen(
+                                selectedValue = suggestionStripEnabled,
+                                topRowMode = topRowMode,
+                                onSelect = { enabled ->
+                                    suggestionStripEnabled = enabled
+                                    preferences.suggestionStripEnabled = enabled
                                 },
                                 onBackClick = { backStack.removeLastOrNull() },
                             )

--- a/app/src/main/kotlin/com/shagalalab/qqkeyboard/keyboard/compose/QqKeyboard.kt
+++ b/app/src/main/kotlin/com/shagalalab/qqkeyboard/keyboard/compose/QqKeyboard.kt
@@ -56,10 +56,19 @@ fun QqKeyboard(
             val topRowMode = viewModel.topRowMode
             val switchButtonText = viewModel.getLayoutSwitchButtonText()
             val bottomRowCommaKey = viewModel.bottomRowCommaKey
-            val updatedLayout = remember(keyboardState.layout, topRowMode, currentImeAction, switchButtonText, bottomRowCommaKey) {
+
+            val isSpecialLayout = viewModel.isPasswordField || keyboardState.layout in setOf(
+                KeyboardLayout.NUMBER_PAD, KeyboardLayout.NUMBER_PASSWORD, KeyboardLayout.PHONE
+            )
+            val showSuggestionStrip = !isSpecialLayout && viewModel.suggestionStripEnabled
+            // Whenever the strip isn't drawn its emoji button goes with it, so the letter
+            // layouts' bottom row takes over as the way into the emoji picker.
+            val showEmojiKey = !showSuggestionStrip
+
+            val updatedLayout = remember(keyboardState.layout, topRowMode, currentImeAction, switchButtonText, bottomRowCommaKey, showEmojiKey) {
                 val baseLayout = when (keyboardState.layout) {
-                    KeyboardLayout.LATIN -> KeyboardMappings.getLatinLayout(topRowMode, currentImeAction)
-                    KeyboardLayout.CYRILLIC -> KeyboardMappings.getCyrillicLayout(topRowMode, currentImeAction)
+                    KeyboardLayout.LATIN -> KeyboardMappings.getLatinLayout(topRowMode, currentImeAction, showEmojiKey)
+                    KeyboardLayout.CYRILLIC -> KeyboardMappings.getCyrillicLayout(topRowMode, currentImeAction, showEmojiKey)
                     KeyboardLayout.NUMERIC -> KeyboardMappings.getNumericLayout(currentImeAction)
                     KeyboardLayout.SYMBOLIC -> KeyboardMappings.getSymbolicLayout(currentImeAction)
                     KeyboardLayout.NUMBER_PAD -> KeyboardMappings.getNumberPadLayout(currentImeAction)
@@ -85,11 +94,8 @@ fun QqKeyboard(
                 else -> 10
             }
 
-            val isSpecialLayout = viewModel.isPasswordField || keyboardState.layout in setOf(
-                KeyboardLayout.NUMBER_PAD, KeyboardLayout.NUMBER_PASSWORD, KeyboardLayout.PHONE
-            )
             val keyAreaHeight = keyHeight * numRows + effectiveRowGap * (numRows - 1) + KeyboardDimensions.gridVerticalPadding * 2
-            val totalHeight = keyAreaHeight + if (isSpecialLayout) 0.dp else KeyboardDimensions.suggestionStripHeight
+            val totalHeight = keyAreaHeight + if (showSuggestionStrip) KeyboardDimensions.suggestionStripHeight else 0.dp
 
             Box(
                 Modifier
@@ -97,7 +103,7 @@ fun QqKeyboard(
                     .height(totalHeight)
             ) {
                 Column(Modifier.fillMaxWidth()) {
-                    if (!isSpecialLayout) {
+                    if (showSuggestionStrip) {
                         SuggestionStrip(
                             suggestions = viewModel.suggestions,
                             isEmojiShown = keyboardState.isEmojiShown,

--- a/app/src/main/kotlin/com/shagalalab/qqkeyboard/keyboard/data/KeyboardMappings.kt
+++ b/app/src/main/kotlin/com/shagalalab/qqkeyboard/keyboard/data/KeyboardMappings.kt
@@ -6,8 +6,23 @@ import com.shagalalab.qqkeyboard.keyboard.model.TopRowMode
 
 object KeyboardMappings {
 
+    // The emoji key only exists when the suggestion strip is hidden — otherwise the strip's own
+    // emoji button is the entry point. It sits to the right of the space bar and borrows its
+    // width from it, so the bottom row keeps the same total and the other keys don't shift.
+    // Only the letter layouts get it; from the numeric and symbolic layouts the way to emoji is
+    // ABC first.
+    private fun spaceAndEmoji(showEmojiKey: Boolean): List<KeyData> = if (showEmojiKey) {
+        listOf(KeyData.space(widthRatio = 3f), KeyData.emoji())
+    } else {
+        listOf(KeyData.space())
+    }
+
     // Latin keyboard layout (QWERTY-based with Karakalpak modifications)
-    fun getLatinLayout(topRowMode: TopRowMode = TopRowMode.EXTRA_LETTERS, imeAction: Int? = null): List<List<KeyData>> {
+    fun getLatinLayout(
+        topRowMode: TopRowMode = TopRowMode.EXTRA_LETTERS,
+        imeAction: Int? = null,
+        showEmojiKey: Boolean = false,
+    ): List<List<KeyData>> {
         val topRow = if (topRowMode == TopRowMode.NUMBERS) {
             listOf(
                 KeyData.character("1"), KeyData.character("2"), KeyData.character("3"),
@@ -64,7 +79,7 @@ object KeyboardMappings {
                 KeyData.modeSwitch("123"),
                 KeyData.character(",", ","),
                 KeyData.layoutSwitch(R.drawable.layout_switch_to_cyr),
-                KeyData.space(),
+            ) + spaceAndEmoji(showEmojiKey) + listOf(
                 KeyData.character(".", "."),
                 KeyData.enterDynamic(imeAction)
             )
@@ -94,7 +109,11 @@ object KeyboardMappings {
     }
 
     // Cyrillic keyboard layout
-    fun getCyrillicLayout(topRowMode: TopRowMode = TopRowMode.EXTRA_LETTERS, imeAction: Int? = null): List<List<KeyData>> {
+    fun getCyrillicLayout(
+        topRowMode: TopRowMode = TopRowMode.EXTRA_LETTERS,
+        imeAction: Int? = null,
+        showEmojiKey: Boolean = false,
+    ): List<List<KeyData>> {
         val topRow = if (topRowMode == TopRowMode.NUMBERS) {
             listOf(
                 KeyData.character("1"), KeyData.character("2"), KeyData.character("3"),
@@ -157,7 +176,7 @@ object KeyboardMappings {
                 KeyData.modeSwitch("123"),
                 KeyData.character(",", ","),
                 KeyData.layoutSwitch(R.drawable.layout_switch_to_lat),
-                KeyData.space(),
+            ) + spaceAndEmoji(showEmojiKey) + listOf(
                 KeyData.character(".", "."),
                 KeyData.enterDynamic(imeAction),
             )

--- a/app/src/main/kotlin/com/shagalalab/qqkeyboard/keyboard/model/KeyData.kt
+++ b/app/src/main/kotlin/com/shagalalab/qqkeyboard/keyboard/model/KeyData.kt
@@ -68,11 +68,18 @@ data class KeyData(
             }
         }
 
-        fun space() = KeyData(
+        fun space(widthRatio: Float = 4f) = KeyData(
             code = "SPACE",
             keyType = KeyType.SPACE,
             iconResId = R.drawable.ic_space,
-            widthRatio = 4f
+            widthRatio = widthRatio
+        )
+
+        fun emoji() = KeyData(
+            code = "EMOJI",
+            keyType = KeyType.CHARACTER,
+            iconResId = R.drawable.ic_smile,
+            widthRatio = 1f
         )
 
         fun layoutSwitch(iconResId: Int) = KeyData(

--- a/app/src/main/kotlin/com/shagalalab/qqkeyboard/keyboard/preferences/KeyboardPreferences.kt
+++ b/app/src/main/kotlin/com/shagalalab/qqkeyboard/keyboard/preferences/KeyboardPreferences.kt
@@ -100,6 +100,10 @@ class KeyboardPreferences(context: Context) {
         get() = prefs.getBoolean(KEY_KEY_BORDER, true)
         set(value) { prefs.edit { putBoolean(KEY_KEY_BORDER, value) } }
 
+    var suggestionStripEnabled: Boolean
+        get() = prefs.getBoolean(KEY_SUGGESTION_STRIP, true)
+        set(value) { prefs.edit { putBoolean(KEY_SUGGESTION_STRIP, value) } }
+
     var vibrationStrength: VibrationStrength
         get() {
             val name = prefs.getString(KEY_VIBRATION_STRENGTH, VibrationStrength.MEDIUM.name)
@@ -191,6 +195,7 @@ class KeyboardPreferences(context: Context) {
         private const val KEY_DOUBLE_SPACE_PERIOD = "double_space_period"
         private const val KEY_KEYBOARD_HEIGHT = "keyboard_height"
         private const val KEY_KEY_BORDER = "key_border_enabled"
+        private const val KEY_SUGGESTION_STRIP = "suggestion_strip_enabled"
         private const val KEY_VIBRATION_STRENGTH = "vibration_strength"
         private const val KEY_MIGRATION_V1_DONE = "migration_v1_done"
         private const val MAX_RECENT_EMOJIS = KeyboardDimensions.emojiGridColumns * 5

--- a/app/src/main/kotlin/com/shagalalab/qqkeyboard/keyboard/viewmodel/KeyboardViewModel.kt
+++ b/app/src/main/kotlin/com/shagalalab/qqkeyboard/keyboard/viewmodel/KeyboardViewModel.kt
@@ -55,6 +55,9 @@ class KeyboardViewModel : ViewModel() {
     var keyBorderEnabled by mutableStateOf(true)
         private set
 
+    var suggestionStripEnabled by mutableStateOf(true)
+        private set
+
     var isPasswordField by mutableStateOf(false)
         private set
 
@@ -111,6 +114,7 @@ class KeyboardViewModel : ViewModel() {
         topRowMode = prefs.topRowMode
         keyboardHeight = prefs.keyboardHeight
         keyBorderEnabled = prefs.keyBorderEnabled
+        suggestionStripEnabled = prefs.suggestionStripEnabled
     }
 
     fun setInputConnection(connection: InputConnection?) {
@@ -425,6 +429,14 @@ class KeyboardViewModel : ViewModel() {
     }
 
     private fun updateSuggestions() {
+        // With the strip hidden there is nowhere to show suggestions, so skip the lookups
+        // entirely. Word learning stays on (see learnCurrentWord) so the dictionary is still
+        // useful if the user turns the strip back on.
+        if (!suggestionStripEnabled) {
+            suggestionJob?.cancel()
+            suggestions = emptyList()
+            return
+        }
         if (!isSuggestionsAllowed()) { suggestions = emptyList(); return }
         val script = currentScript() ?: run { suggestions = emptyList(); return }
 

--- a/app/src/main/kotlin/com/shagalalab/qqkeyboard/ui/settings/SettingsNavKeys.kt
+++ b/app/src/main/kotlin/com/shagalalab/qqkeyboard/ui/settings/SettingsNavKeys.kt
@@ -10,4 +10,5 @@ sealed interface SettingsNavKey : NavKey
 @Serializable data object ThemeSelection : SettingsNavKey
 @Serializable data object HeightSelection : SettingsNavKey
 @Serializable data object VibrationSelection : SettingsNavKey
+@Serializable data object SuggestionStripSelection : SettingsNavKey
 @Serializable data object TopRowSelection : SettingsNavKey

--- a/app/src/main/kotlin/com/shagalalab/qqkeyboard/ui/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/shagalalab/qqkeyboard/ui/settings/SettingsScreen.kt
@@ -42,6 +42,8 @@ fun SettingsScreen(
     onKeyboardHeightClick: () -> Unit,
     vibrationStrength: VibrationStrength,
     onVibrationStrengthClick: () -> Unit,
+    suggestionStripEnabled: Boolean,
+    onSuggestionStripClick: () -> Unit,
     topRowMode: TopRowMode,
     onTopRowModeClick: () -> Unit,
 ) {
@@ -148,7 +150,7 @@ fun SettingsScreen(
                 }
                 SegmentedListItem(
                     onClick = onKeyboardHeightClick,
-                    shapes = ListItemDefaults.segmentedShapes(2, 5),
+                    shapes = ListItemDefaults.segmentedShapes(1, 5),
                     supportingContent = {
                         Text(
                             when (keyboardHeight) {
@@ -170,13 +172,29 @@ fun SettingsScreen(
                         keyBorderEnabled = !keyBorderEnabled
                         preferences.keyBorderEnabled = keyBorderEnabled
                     },
-                    shapes = ListItemDefaults.segmentedShapes(3, 5),
+                    shapes = ListItemDefaults.segmentedShapes(2, 5),
                     trailingContent = {
                         Switch(checked = keyBorderEnabled, onCheckedChange = null)
                     },
                     colors = ListItemDefaults.colors(containerColor = MaterialTheme.colorScheme.secondaryContainer)
                 ) {
                     Text(stringResource(R.string.settings_key_border))
+                }
+                SegmentedListItem(
+                    onClick = onSuggestionStripClick,
+                    shapes = ListItemDefaults.segmentedShapes(3, 5),
+                    supportingContent = {
+                        Text(
+                            if (suggestionStripEnabled) stringResource(R.string.settings_suggestion_strip_on)
+                            else stringResource(R.string.settings_suggestion_strip_off)
+                        )
+                    },
+                    trailingContent = {
+                        Icon(painter = painterResource(R.drawable.chevron_right_24px), contentDescription = null)
+                    },
+                    colors = ListItemDefaults.colors(containerColor = MaterialTheme.colorScheme.secondaryContainer)
+                ) {
+                    Text(stringResource(R.string.settings_suggestion_strip))
                 }
                 SegmentedListItem(
                     onClick = onTopRowModeClick,

--- a/app/src/main/kotlin/com/shagalalab/qqkeyboard/ui/settings/SuggestionStripScreen.kt
+++ b/app/src/main/kotlin/com/shagalalab/qqkeyboard/ui/settings/SuggestionStripScreen.kt
@@ -1,0 +1,134 @@
+package com.shagalalab.qqkeyboard.ui.settings
+
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.shagalalab.qqkeyboard.R
+import com.shagalalab.qqkeyboard.keyboard.compose.KeyboardLayout
+import com.shagalalab.qqkeyboard.keyboard.compose.SuggestionStrip
+import com.shagalalab.qqkeyboard.keyboard.data.KeyboardMappings
+import com.shagalalab.qqkeyboard.keyboard.model.KeyboardHeight
+import com.shagalalab.qqkeyboard.keyboard.model.TopRowMode
+import com.shagalalab.qqkeyboard.keyboard.theme.KeyboardThemes
+import com.shagalalab.qqkeyboard.keyboard.theme.LocalKeyboardBorderEnabled
+import com.shagalalab.qqkeyboard.keyboard.theme.LocalKeyboardColors
+import com.shagalalab.qqkeyboard.keyboard.theme.LocalKeyboardHeight
+
+// Stand-ins for real suggestions, so the preview shows what the strip looks like in use.
+private val PREVIEW_SUGGESTIONS = listOf("men", "sálem", "sen")
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SuggestionStripScreen(
+    selectedValue: Boolean,
+    topRowMode: TopRowMode,
+    onSelect: (Boolean) -> Unit,
+    onBackClick: () -> Unit,
+) {
+    val options = listOf(
+        SelectionOption(
+            value = true,
+            label = stringResource(R.string.settings_suggestion_strip_on),
+        ),
+        SelectionOption(
+            value = false,
+            label = stringResource(R.string.settings_suggestion_strip_off),
+        ),
+    )
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(R.string.settings_suggestion_strip)) },
+                navigationIcon = {
+                    IconButton(onClick = onBackClick) {
+                        Icon(
+                            painter = painterResource(R.drawable.arrow_back_24px),
+                            contentDescription = stringResource(R.string.cd_back)
+                        )
+                    }
+                },
+            )
+        },
+    ) { contentPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(contentPadding)
+        ) {
+            RadioOptionList(
+                options = options,
+                selectedValue = selectedValue,
+                onSelect = onSelect,
+            )
+            SuggestionStripPreview(
+                showStrip = selectedValue,
+                topRowMode = topRowMode,
+                modifier = Modifier.padding(16.dp),
+            )
+        }
+    }
+}
+
+@Composable
+private fun SuggestionStripPreview(
+    showStrip: Boolean,
+    topRowMode: TopRowMode,
+    modifier: Modifier = Modifier,
+) {
+    val colors = KeyboardThemes.SystemAuto.resolvedColors(isSystemInDarkTheme())
+    val previewRows = KeyboardMappings.getLatinLayout(topRowMode).take(1)
+
+    CompositionLocalProvider(
+        LocalKeyboardColors provides colors,
+        LocalKeyboardHeight provides KeyboardHeight.DEFAULT,
+        LocalKeyboardBorderEnabled provides true,
+    ) {
+        Column(modifier = modifier) {
+            Text(
+                text = stringResource(R.string.settings_preview),
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(bottom = 8.dp),
+            )
+            Surface(
+                color = colors.keyboardBackground,
+                shape = RoundedCornerShape(12.dp),
+            ) {
+                Column {
+                    if (showStrip) {
+                        SuggestionStrip(
+                            suggestions = PREVIEW_SUGGESTIONS,
+                            isEmojiShown = false,
+                            onSuggestionClick = {},
+                            onEmojiToggle = {},
+                        )
+                    }
+                    KeyboardLayout(
+                        rows = previewRows,
+                        maxKeysInRow = 10,
+                        onKeyClick = {},
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -53,6 +53,8 @@
     <string name="settings_auto_remove_space">Irkilis belgileri aldındaǵı probeldi avtomat túrde óshiriw</string>
     <string name="settings_double_space_period">Qos probel noqatqa aylanadı</string>
     <string name="settings_suggestion_strip">Sózlerdi usınıs etiw</string>
+    <string name="settings_suggestion_strip_on">Qosılǵan</string>
+    <string name="settings_suggestion_strip_off">Óshirilgen</string>
     <string name="settings_theme">Tema</string>
     <string name="settings_select_theme">Temanı tańlaw</string>
     <string name="settings_keyboard_height">Klaviatura biyikligi</string>


### PR DESCRIPTION
Some users don't want the suggestion strip, so this makes it optional. It stays visible by default.

## Behaviour

- **Height**: when the strip is hidden the keyboard shrinks by its full 40dp — the strip isn't just emptied out. This reuses the path that already hides the strip for password and number fields.
- **Emoji key**: with the strip gone its emoji button goes too, so the Latin and Cyrillic bottom rows grow an emoji key to the right of the space bar — where the old keyboard had it. It borrows its width from the space bar (4f → 3f), so the row total is unchanged and no other key moves. The numeric and symbolic layouts don't get one; `ABC` first, then emoji.
- **Password fields**: these already hid the strip, which left emoji unreachable there. The key is keyed off "strip not drawn" rather than the preference alone, so they get the emoji key too.
- **Suggestions**: with the strip off, `updateSuggestions()` returns before touching the database. Word learning is deliberately left running, so the dictionary is still useful if the strip is turned back on.

## Settings

The item sits in Appearance, just above "Joqarǵı qatar", and opens its own screen rather than being a switch — radio options for on/off with a live preview below, following `TopRowModeScreen`. The preview honours the current top-row setting.

⚠️ The two new strings (`settings_suggestion_strip_on` → "Qosılǵan", `settings_suggestion_strip_off` → "Óshirilgen") need a native check before merging.

## Testing

`compileDebugKotlin` passes; the project has no unit tests. **Not verified on a device** — `installDebug` fails on both the emulator and the phone with `INSTALL_FAILED_UPDATE_INCOMPATIBLE`, since a release-signed build is installed on each. Worth a look on device before merge, particularly the emoji key's appearance in the bottom row and the shorter emoji panel when the strip is off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)